### PR TITLE
update ownership model from Cow to String

### DIFF
--- a/ChatGPT context
+++ b/ChatGPT context
@@ -1,135 +1,135 @@
-pub enum Document<'a> {
+pub enum Document {
     Prolog {
-        xml_decl: Option<XmlDecl<'a>>,
-        misc: Option<Vec<Misc<'a>>>,
-        doc_type: Option<DocType<'a>>,
+        xml_decl: Option<XmlDecl>,
+        misc: Option<Vec<Misc>>,
+        doc_type: Option<DocType>,
     },
-    Element(Tag<'a>, Box<Document<'a>>, Tag<'a>),
-    Content(Option<Cow<'a, str>>),
-    Nested(Vec<Document<'a>>),
+    Element(Tag, Box<Document>, Tag),
+    Content(Option<String>),
+    Nested(Vec<Document>),
     Empty,
-    EmptyTag(Tag<'a>),
-    ProcessingInstruction(ProcessingInstruction<'a>),
-    Comment(Cow<'a, str>),
-    CDATA(Cow<'a, str>),
+    EmptyTag(Tag),
+    ProcessingInstruction(ProcessingInstruction),
+    Comment(String),
+    CDATA(String),
 }
 pub enum TagState {
     Start,
     End,
     Empty,
 }
-pub struct Tag<'a> {
-    pub name: Name<'a>,
-    pub attributes: Option<Vec<Attribute<'a>>>, // Attribute::Instance
+pub struct Tag {
+    pub name: Name,
+    pub attributes: Option<Vec<Attribute>>, // Attribute::Instance
     pub state: TagState,
 }
-pub struct DocType<'a> {
-    pub name: Name<'a>,
-    pub external_id: Option<ExternalID<'a>>,
-    pub int_subset: Option<Vec<InternalSubset<'a>>>,
+pub struct DocType {
+    pub name: Name,
+    pub external_id: Option<ExternalID>,
+    pub int_subset: Option<Vec<InternalSubset>>,
 }
-pub enum EntityValue<'a> {
-    Document(Document<'a>),
-    Value(Cow<'a, str>),
-    Reference(Reference<'a>),
-    ParameterReference(Reference<'a>),
-    InternalSubset(Box<InternalSubset<'a>>),
+pub enum EntityValue {
+    Document(Document),
+    Value(String),
+    Reference(Reference),
+    ParameterReference(Reference),
+    InternalSubset(Box<InternalSubset>),
 }
 
-pub enum EntityDecl<'a> {
-    General(GeneralEntityDeclaration<'a>),
-    Parameter(ParameterEntityDeclaration<'a>),
+pub enum EntityDecl {
+    General(GeneralEntityDeclaration),
+    Parameter(ParameterEntityDeclaration),
 }
-pub struct EntityDeclaration<'a> {
-    pub name: Name<'a>,
-    pub entity_def: EntityDefinition<'a>,
+pub struct EntityDeclaration {
+    pub name: Name,
+    pub entity_def: EntityDefinition,
 }
-pub type GeneralEntityDeclaration<'a> = EntityDeclaration<'a>;
-pub type ParameterEntityDeclaration<'a> = EntityDeclaration<'a>;
+pub type GeneralEntityDeclaration = EntityDeclaration;
+pub type ParameterEntityDeclaration = EntityDeclaration;
 
-pub enum EntityDefinition<'a> {
-    EntityValue(EntityValue<'a>),
+pub enum EntityDefinition {
+    EntityValue(EntityValue),
     External {
-        id: ExternalID<'a>,
-        n_data: Option<Name<'a>>,
+        id: ExternalID,
+        n_data: Option<Name>,
     },
 }
 
-pub struct EntityDeclaration<'a> {
-    pub name: Name<'a>,
-    pub entity_def: EntityDefinition<'a>,
+pub struct EntityDeclaration {
+    pub name: Name,
+    pub entity_def: EntityDefinition,
 }
-pub type GeneralEntityDeclaration<'a> = EntityDeclaration<'a>;
-pub type ParameterEntityDeclaration<'a> = EntityDeclaration<'a>;
+pub type GeneralEntityDeclaration = EntityDeclaration;
+pub type ParameterEntityDeclaration = EntityDeclaration;
 
-pub enum ID<'a> {
-    ExternalID(ExternalID<'a>),
-    PublicID(Cow<'a, str>),
+pub enum ID {
+    ExternalID(ExternalID),
+    PublicID(String),
 }
-pub enum InternalSubset<'a> {
+pub enum InternalSubset {
     Element {
-        name: QualifiedName<'a>,
-        content_spec: Option<DeclarationContent<'a>>,
+        name: QualifiedName,
+        content_spec: Option<DeclarationContent>,
     },
     AttList {
-        name: QualifiedName<'a>,
-        att_defs: Option<Vec<Attribute<'a>>>,
+        name: QualifiedName,
+        att_defs: Option<Vec<Attribute>>,
     },
     Notation {
-        name: QualifiedName<'a>,
-        id: ID<'a>,
+        name: QualifiedName,
+        id: ID,
     },
-    Entity(EntityDeclaration<'a>),
-    DeclSep(Reference<'a>),
-    ProcessingInstruction(ProcessingInstruction<'a>),
-    Comment(Document<'a>),
+    Entity(EntityDeclaration),
+    DeclSep(Reference),
+    ProcessingInstruction(ProcessingInstruction),
+    Comment(Document),
 }
 pub enum Standalone {
     Yes,
     No,
 }
-pub enum DeclarationContent<'a> {
-    Mixed(Mixed<'a>),
-    Children(ContentParticle<'a>),
+pub enum DeclarationContent {
+    Mixed(Mixed),
+    Children(ContentParticle),
     Empty,
     Any,
 }
-pub enum Mixed<'a> {
+pub enum Mixed {
     PCDATA {
-        names: Option<Vec<QualifiedName<'a>>>,
+        names: Option<Vec<QualifiedName>>,
         parsed: bool,
     },
 }
-pub struct XmlDecl<'a> {
-    pub version: Cow<'a, str>,
-    pub encoding: Option<Cow<'a, str>>,
+pub struct XmlDecl {
+    pub version: String,
+    pub encoding: Option<String>,
     pub standalone: Option<Standalone>,
 }
-pub struct QualifiedName<'a> {
-    pub prefix: Option<Cow<'a, str>>,
-    pub local_part: Cow<'a, str>,
+pub struct QualifiedName {
+    pub prefix: Option<String>,
+    pub local_part: String,
 }
-pub type Name<'a> = QualifiedName<'a>;
-pub enum Prefix<'a> {
+pub type Name = QualifiedName;
+pub enum Prefix {
     Default,
-    Prefix(Cow<'a, str>),
+    Prefix(String),
 }
-pub enum Attribute<'a> {
+pub enum Attribute {
     Definition {
-        name: QualifiedName<'a>,
-        att_type: AttType<'a>,
-        default_decl: DefaultDecl<'a>,
+        name: QualifiedName,
+        att_type: AttType,
+        default_decl: DefaultDecl,
     },
-    Reference(Reference<'a>),
+    Reference(Reference),
     Instance {
-        name: QualifiedName<'a>,
-        value: Cow<'a, str>,
+        name: QualifiedName,
+        value: String,
     },
     Required,
     Implied,
     Namespace {
-        prefix: Prefix<'a>,
-        uri: Cow<'a, str>,
+        prefix: Prefix,
+        uri: String,
     },
 }
 pub enum TokenizedType {
@@ -141,19 +141,19 @@ pub enum TokenizedType {
     NMTOKEN,
     NMTOKENS,
 }
-pub enum AttType<'a> {
+pub enum AttType {
     CDATA,
     Tokenized(TokenizedType),
     Enumerated {
-        notation: Option<Vec<Name<'a>>>,
-        enumeration: Option<Vec<Cow<'a, str>>>,
+        notation: Option<Vec<Name>>,
+        enumeration: Option<Vec<String>>,
     },
 }
-pub enum DefaultDecl<'a> {
+pub enum DefaultDecl {
     Required,
     Implied,
-    Fixed(Cow<'a, str>),
-    Value(Cow<'a, str>),
+    Fixed(String),
+    Value(String),
 }
 pub enum ConditionalState {
     None,
@@ -161,23 +161,23 @@ pub enum ConditionalState {
     ZeroOrMore,
     OneOrMore,
 }
-pub enum ContentParticle<'a> {
-    Name(QualifiedName<'a>, ConditionalState),
-    Choice(Vec<ContentParticle<'a>>, ConditionalState),
-    Sequence(Vec<ContentParticle<'a>>, ConditionalState),
+pub enum ContentParticle {
+    Name(QualifiedName, ConditionalState),
+    Choice(Vec<ContentParticle>, ConditionalState),
+    Sequence(Vec<ContentParticle>, ConditionalState),
 }
-pub enum ExternalID<'a> {
-    System(Cow<'a, str>),
+pub enum ExternalID {
+    System(String),
     Public {
-        pubid: Cow<'a, str>,
-        system_identifier: Box<ExternalID<'a>>, // Box<ExternalID::System>
+        pubid: String,
+        system_identifier: Box<ExternalID>, // Box<ExternalID::System>
     },
 }
-pub struct ProcessingInstruction<'a> {
-    pub target: Name<'a>,
-    pub data: Option<Cow<'a, str>>,
+pub struct ProcessingInstruction {
+    pub target: Name,
+    pub data: Option<String>,
 }
-pub enum Reference<'a> {
-    EntityRef(Name<'a>),
-    CharRef { value: Cow<'a, str> },
+pub enum Reference {
+    EntityRef(Name),
+    CharRef { value: String },
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -26,14 +26,14 @@ fn fmt_indented(f: &mut String, indent: usize, s: &str) {
     f.push_str(&" ".repeat(indent));
     f.push_str(s);
 }
-impl<'a> fmt::Debug for Tag<'a> {
+impl fmt::Debug for Tag {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut s = String::new();
         self.fmt_indented_tag(&mut s, 0);
         write!(f, "{}", s)
     }
 }
-impl<'a> Tag<'a> {
+impl Tag {
     fn fmt_indented_tag(&self, f: &mut String, indent: usize) {
         let Tag {
             name,
@@ -68,13 +68,13 @@ impl<'a> Tag<'a> {
     }
 }
 
-impl<'a> fmt::Debug for QualifiedName<'a> {
+impl fmt::Debug for QualifiedName {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.fmt_qualified_name(0))
     }
 }
 
-impl<'a> QualifiedName<'a> {
+impl QualifiedName {
     fn fmt_qualified_name(&self, indent: usize) -> String {
         let QualifiedName { prefix, local_part } = self;
         let mut f = String::new();
@@ -121,7 +121,7 @@ impl MiscState {
     }
 }
 
-impl<'a> fmt::Debug for Misc<'a> {
+impl fmt::Debug for Misc {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut s = String::new();
         self.fmt_indented_misc(&mut s, 0);
@@ -129,7 +129,7 @@ impl<'a> fmt::Debug for Misc<'a> {
     }
 }
 
-impl<'a> Misc<'a> {
+impl Misc {
     fn fmt_indented_misc(&self, f: &mut String, indent: usize) {
         fmt_indented(f, indent, "Misc {\n");
         fmt_indented(f, indent + 4, &format!("content: {:?}", self.content));
@@ -138,7 +138,7 @@ impl<'a> Misc<'a> {
     }
 }
 
-impl<'a> Document<'a> {
+impl Document {
     fn fmt_indented_doc(&self, f: &mut String, indent: usize) {
         match self {
             Document::Prolog {
@@ -217,17 +217,13 @@ impl<'a> Document<'a> {
             }
 
             Document::CDATA(cdata) => {
-                fmt_indented(
-                    f,
-                    indent,
-                    &format!("CDATA(\"{}\"),\n", cdata.clone().as_ref()),
-                );
+                fmt_indented(f, indent, &format!("CDATA(\"{}\"),\n", cdata.clone()));
             }
         }
     }
 }
 
-impl<'a> fmt::Debug for Document<'a> {
+impl fmt::Debug for Document {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut s = String::new();
         self.fmt_indented_doc(&mut s, 0);
@@ -235,7 +231,7 @@ impl<'a> fmt::Debug for Document<'a> {
     }
 }
 
-impl<'a> DeclarationContent<'a> {
+impl DeclarationContent {
     fn fmt_indented_dec_content(&self, f: &mut String, indent: usize) {
         match self {
             DeclarationContent::Mixed(mixed) => {
@@ -260,7 +256,7 @@ impl<'a> DeclarationContent<'a> {
     }
 }
 
-impl<'a> fmt::Debug for DeclarationContent<'a> {
+impl fmt::Debug for DeclarationContent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = String::new();
         self.fmt_indented_dec_content(&mut s, 0);
@@ -268,7 +264,7 @@ impl<'a> fmt::Debug for DeclarationContent<'a> {
     }
 }
 
-impl<'a> Mixed<'a> {
+impl Mixed {
     fn fmt_indented_mixed(&self, f: &mut String, indent: usize) {
         match self {
             Mixed::PCDATA { names, parsed } => {
@@ -282,14 +278,14 @@ impl<'a> Mixed<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Mixed<'a> {
+impl fmt::Debug for Mixed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = String::new();
         self.fmt_indented_mixed(&mut s, 0);
         write!(f, "{}", s)
     }
 }
-impl<'a> ContentParticle<'a> {
+impl ContentParticle {
     fn fmt_indented_content_particle(&self, f: &mut String, indent: usize) {
         match self {
             ContentParticle::Name(name, conditional_state) => {
@@ -343,7 +339,7 @@ impl fmt::Debug for Standalone {
     }
 }
 
-impl<'a> XmlDecl<'a> {
+impl XmlDecl {
     fn fmt_indented_xml_decl(&self, f: &mut String, indent: usize) {
         fmt_indented(f, indent, "XmlDecl {\n");
         fmt_indented(f, indent + 4, &format!("version: {:?},\n", self.version));
@@ -357,7 +353,7 @@ impl<'a> XmlDecl<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for DocType<'a> {
+impl std::fmt::Debug for DocType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DocType")
             .field("name", &self.name)
@@ -367,7 +363,7 @@ impl<'a> std::fmt::Debug for DocType<'a> {
     }
 }
 
-impl<'a> DocType<'a> {
+impl DocType {
     fn fmt_indented_doc_type(&self, f: &mut String, indent: usize) {
         fmt_indented(f, indent, "DocType {\n");
         fmt_indented(
@@ -388,7 +384,7 @@ impl<'a> DocType<'a> {
         fmt_indented(f, indent, "},\n");
     }
 }
-impl<'a> ExternalID<'a> {
+impl ExternalID {
     fn fmt_indented_external_id(&self, f: &mut String, indent: usize) {
         match self {
             ExternalID::System(system) => {
@@ -408,7 +404,7 @@ impl<'a> ExternalID<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for ID<'a> {
+impl std::fmt::Debug for ID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ID::ExternalID(external_id) => f.debug_tuple("ExternalID").field(&external_id).finish(),
@@ -417,7 +413,7 @@ impl<'a> std::fmt::Debug for ID<'a> {
     }
 }
 
-impl<'a> ID<'a> {
+impl ID {
     fn fmt_indented_id(&self, f: &mut String, indent: usize) {
         match self {
             ID::ExternalID(external_id) => {
@@ -432,7 +428,7 @@ impl<'a> ID<'a> {
     }
 }
 
-impl<'a> InternalSubset<'a> {
+impl InternalSubset {
     fn fmt_internal_subset(&self, f: &mut String, indent: usize) {
         match self {
             InternalSubset::Element { name, content_spec } => {
@@ -547,7 +543,7 @@ impl<'a> InternalSubset<'a> {
     }
 }
 
-impl<'a> fmt::Debug for InternalSubset<'a> {
+impl fmt::Debug for InternalSubset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = String::new();
         self.fmt_internal_subset(&mut s, 0);
@@ -555,7 +551,7 @@ impl<'a> fmt::Debug for InternalSubset<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for XmlDecl<'a> {
+impl std::fmt::Debug for XmlDecl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("XmlDecl")
             .field("version", &self.version)
@@ -565,7 +561,7 @@ impl<'a> std::fmt::Debug for XmlDecl<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for AttributeValue<'a> {
+impl std::fmt::Debug for AttributeValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_string = String::new();
         self.fmt_indented_attribute_value(&mut debug_string, 4);
@@ -573,7 +569,7 @@ impl<'a> std::fmt::Debug for AttributeValue<'a> {
     }
 }
 
-impl<'a> AttributeValue<'a> {
+impl AttributeValue {
     fn fmt_indented_attribute_value(&self, f: &mut String, indent: usize) {
         match self {
             AttributeValue::Value(value) => {
@@ -597,7 +593,7 @@ impl<'a> AttributeValue<'a> {
     }
 }
 
-impl<'a> Attribute<'a> {
+impl Attribute {
     fn fmt_indented_attribute(&self, f: &mut String, indent: usize) {
         match self {
             Attribute::Definition {
@@ -644,7 +640,7 @@ impl<'a> Attribute<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Attribute<'a> {
+impl fmt::Debug for Attribute {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = String::new();
         self.fmt_indented_attribute(&mut s, 0);
@@ -652,7 +648,7 @@ impl<'a> fmt::Debug for Attribute<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Prefix<'a> {
+impl fmt::Debug for Prefix {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Prefix::Default => write!(f, "Default"),
@@ -661,7 +657,7 @@ impl<'a> fmt::Debug for Prefix<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Reference<'a> {
+impl fmt::Debug for Reference {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Reference::EntityRef(entity) => f
@@ -676,7 +672,7 @@ impl<'a> fmt::Debug for Reference<'a> {
     }
 }
 
-impl<'a> fmt::Debug for EntityDeclaration<'a> {
+impl fmt::Debug for EntityDeclaration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EntityDeclaration")
             .field("name", &self.name)
@@ -685,7 +681,7 @@ impl<'a> fmt::Debug for EntityDeclaration<'a> {
     }
 }
 
-impl<'a> EntityDeclaration<'a> {
+impl EntityDeclaration {
     fn fmt_indented_entity_declaration(&self, f: &mut String, indent: usize) {
         fmt_indented(f, indent, "EntityDeclaration {\n");
         fmt_indented(
@@ -703,7 +699,7 @@ impl<'a> EntityDeclaration<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for EntityDefinition<'a> {
+impl std::fmt::Debug for EntityDefinition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut s = String::new();
         self.fmt_indented_entity_definition(&mut s, 0);
@@ -711,7 +707,7 @@ impl<'a> std::fmt::Debug for EntityDefinition<'a> {
     }
 }
 
-impl<'a> EntityDefinition<'a> {
+impl EntityDefinition {
     fn fmt_indented_entity_definition(&self, f: &mut String, indent: usize) {
         match self {
             EntityDefinition::EntityValue(value) => {
@@ -731,7 +727,7 @@ impl<'a> EntityDefinition<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for EntityValue<'a> {
+impl std::fmt::Debug for EntityValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             EntityValue::Value(value) => {
@@ -759,7 +755,7 @@ impl<'a> std::fmt::Debug for EntityValue<'a> {
     }
 }
 
-impl<'a> EntityValue<'a> {
+impl EntityValue {
     fn fmt_indented_entity_value(&self, f: &mut String, indent: usize) {
         match self {
             EntityValue::Value(value) => {

--- a/src/io.rs
+++ b/src/io.rs
@@ -8,7 +8,6 @@ use std::{
     fs::{self, File},
     io::Read,
 };
-
 fn read_file(file: &mut File) -> std::io::Result<String> {
     let mut reader = BufReader::new(file);
     let mut bytes = vec![];
@@ -24,15 +23,11 @@ fn read_file(file: &mut File) -> std::io::Result<String> {
     Ok(decoded_str.into_owned())
 }
 
-pub fn parse_file<'a>(
-    file: &mut File,
-    buffer: &'a mut String,
-) -> Result<Document<'a>, CustomError> {
-    buffer.clear();
-    buffer.push_str(&read_file(file)?);
-    buffer.replace_range(.., &buffer.replace("\r\n", "\n"));
+pub fn parse_file(file: &mut File) -> Result<Document, CustomError> {
+    let mut data = read_file(file)?;
+    data = data.replace("\r\n", "\n");
 
-    let (_, document) = Document::parse_xml_str(buffer).map_err(|err| match err {
+    let (_, document) = Document::parse_xml_str(&mut data).map_err(|err| match err {
         nom::Err::Error(e) | nom::Err::Failure(e) => {
             CustomError::NomError(format!("error: {:?}, input: {}", e.code, e.input))
         }
@@ -42,16 +37,16 @@ pub fn parse_file<'a>(
     Ok(document)
 }
 
-// pub fn parse_directory(path: &Path) -> Result<Vec<Result<Document, CustomError>>, CustomError> {
-//     let entries = fs::read_dir(path)?;
-//     let results = entries
-//         .par_bridge()
-//         .filter_map(Result::ok)
-//         .filter(|entry| entry.path().extension().and_then(|s| s.to_str()) == Some("xml")) // Fix the E0369 error by adding `to_str()` here.
-//         .map(|entry| {
-//             let mut file = File::open(entry.path())?;
-//             parse_file(&mut file)
-//         })
-//         .collect::<Vec<_>>();
-//     Ok(results)
-// }
+pub fn parse_directory(path: &Path) -> Result<Vec<Result<Document, CustomError>>, CustomError> {
+    let entries = fs::read_dir(path)?;
+    let results = entries
+        .par_bridge()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().extension().and_then(|s| s.to_str()) == Some("xml"))
+        .map(|entry| {
+            let mut file = File::open(entry.path())?;
+            parse_file(&mut file)
+        })
+        .collect::<Vec<_>>();
+    Ok(results)
+}

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -9,19 +9,19 @@ pub enum MiscState {
 }
 
 #[derive(Clone, PartialEq)]
-pub struct Misc<'a> {
-    pub content: Box<Document<'a>>, // Document::Comment | Document::ProcessingInstruction>
+pub struct Misc {
+    pub content: Box<Document>, // Document::Comment | Document::ProcessingInstruction>
     pub state: MiscState,
 }
 
-impl<'a> Parse<'a> for Misc<'a> {
+impl<'a> Parse<'a> for Misc {
     type Args = MiscState;
     type Output = IResult<&'a str, Self>;
 
     //[27] Misc ::= Comment | PI | S
     fn parse(input: &'a str, args: Self::Args) -> Self::Output {
         let mut input_remaining = input;
-        let mut content_vec: Vec<Document<'a>> = vec![];
+        let mut content_vec: Vec<Document> = vec![];
         loop {
             let parse_result = alt((
                 Document::parse_comment,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -24,7 +24,7 @@ pub trait Parse<'a>: Sized {
         matches!(c, '\u{9}' | '\u{A}' | '\u{D}' | '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}')
     }
 
-    fn parse_char(input: &'a str) -> IResult<&'a str, char> {
+    fn parse_char(input: &str) -> IResult<&str, char> {
         satisfy(Self::is_char)(input)
     }
 
@@ -34,12 +34,12 @@ pub trait Parse<'a>: Sized {
         matches!(c, ' ' | '\t' | '\r' | '\n')
     }
 
-    fn parse_multispace1(input: &'a str) -> IResult<&'a str, ()> {
+    fn parse_multispace1(input: &str) -> IResult<&str, ()> {
         let (input, _) = many1(satisfy(Self::is_whitespace))(input)?;
         Ok((input, ()))
     }
 
-    fn parse_multispace0(input: &'a str) -> IResult<&'a str, ()> {
+    fn parse_multispace0(input: &str) -> IResult<&str, ()> {
         let (input, _) = many0(satisfy(Self::is_whitespace))(input)?;
         Ok((input, ()))
     }
@@ -71,27 +71,27 @@ pub trait Parse<'a>: Sized {
             '\u{0300}'..='\u{036F}' | '\u{203F}'..='\u{2040}')
     }
 
-    fn parse_name_char(input: &'a str) -> IResult<&'a str, char> {
+    fn parse_name_char(input: &str) -> IResult<&str, char> {
         satisfy(Self::is_name_char)(input)
     }
 
-    fn parse_name_start_char(input: &'a str) -> IResult<&'a str, char> {
+    fn parse_name_start_char(input: &str) -> IResult<&str, char> {
         satisfy(Self::is_name_start_char)(input)
     }
 
     // [7] Nmtoken ::= (NameChar)+
-    fn parse_nmtoken(input: &'a str) -> IResult<&'a str, Cow<'a, str>> {
+    fn parse_nmtoken(input: &str) -> IResult<&str, String> {
         let (input, result) = recognize(many1(Self::parse_name_char))(input)?;
-        Ok((input, Cow::Borrowed(result)))
+        Ok((input, result.to_string()))
     }
 
     // [8] Nmtokens ::= Nmtoken (#x20 Nmtoken)*
-    fn parse_nmtokens(input: &'a str) -> IResult<&'a str, Vec<Cow<'a, str>>> {
+    fn parse_nmtokens(input: &str) -> IResult<&str, Vec<String>> {
         separated_list1(char(' '), Self::parse_nmtoken)(input)
     }
 
     // [5] Name ::= NameStartChar (NameChar)*
-    fn parse_name(input: &'a str) -> IResult<&'a str, Name> {
+    fn parse_name(input: &str) -> IResult<&str, Name> {
         map(
             tuple((Self::parse_name_start_char, opt(Self::parse_nmtoken))),
             |(start_char, rest_chars)| {
@@ -108,19 +108,19 @@ pub trait Parse<'a>: Sized {
                 };
                 Name {
                     prefix: None,
-                    local_part: Cow::Owned(local_part),
+                    local_part,
                 }
             },
         )(input)
     }
 
     // [6] Names ::= Name (#x20 Name)*
-    fn parse_names(input: &'a str) -> IResult<&'a str, Vec<Name>> {
+    fn parse_names(input: &str) -> IResult<&str, Vec<Name>> {
         separated_list1(char(' '), Self::parse_name)(input)
     }
 
     //[25] Eq ::=  S? '=' S?
-    fn parse_eq(input: &'a str) -> IResult<&'a str, ()> {
+    fn parse_eq(input: &str) -> IResult<&str, ()> {
         let (input, _) = Self::parse_multispace0(input)?;
         let (input, _) = tag("=")(input)?;
         let (input, _) = Self::parse_multispace0(input)?;

--- a/src/processing_instruction.rs
+++ b/src/processing_instruction.rs
@@ -11,14 +11,15 @@ use nom::{
 use std::borrow::Cow;
 
 #[derive(Clone, PartialEq)]
-pub struct ProcessingInstruction<'a> {
-    pub target: Name<'a>,
-    pub data: Option<Cow<'a, str>>,
+pub struct ProcessingInstruction {
+    pub target: Name,
+    pub data: Option<String>,
 }
 
-impl<'a> Parse<'a> for ProcessingInstruction<'a> {
+impl<'a> Parse<'a> for ProcessingInstruction {
     type Args = ();
     type Output = IResult<&'a str, Self>;
+
     // [16] PI ::= '<?' PITarget (S (Char* - (Char* '?>' Char*)))? '?>'
     fn parse(input: &'a str, _args: Self::Args) -> Self::Output {
         map(
@@ -31,20 +32,17 @@ impl<'a> Parse<'a> for ProcessingInstruction<'a> {
                 )),
                 tag("?>"),
             )),
-            |(_open_tag, target, data_chars, _close_tag)| {
-                let data: Option<String> = data_chars.map(|(chars, _)| chars.into_iter().collect());
-                ProcessingInstruction {
-                    target,
-                    data: data.map(Cow::Owned),
-                }
+            |(_open_tag, target, data_chars_opt, _close_tag)| {
+                let data = data_chars_opt.map(|(chars, _)| chars.into_iter().collect::<String>());
+                ProcessingInstruction { target, data }
             },
         )(input)
     }
 }
 
-impl<'a> ProcessingInstruction<'a> {
+impl ProcessingInstruction {
     //[17] PITarget	::= Name - (('X' | 'x') ('M' | 'm') ('L' | 'l'))
-    fn parse_target(input: &'a str) -> IResult<&'a str, Name> {
+    fn parse_target(input: &str) -> IResult<&str, Name> {
         map_res(Self::parse_name, |name| {
             if name.local_part.eq_ignore_ascii_case("xml") {
                 Err(nom::Err::Failure(nom::error::Error::new(

--- a/src/prolog/content_particle.rs
+++ b/src/prolog/content_particle.rs
@@ -9,13 +9,13 @@ use nom::{
 };
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum ContentParticle<'a> {
-    Name(QualifiedName<'a>, ConditionalState),
-    Choice(Vec<ContentParticle<'a>>, ConditionalState),
-    Sequence(Vec<ContentParticle<'a>>, ConditionalState),
+pub enum ContentParticle {
+    Name(QualifiedName, ConditionalState),
+    Choice(Vec<ContentParticle>, ConditionalState),
+    Sequence(Vec<ContentParticle>, ConditionalState),
 }
-impl<'a> ParseNamespace<'a> for ContentParticle<'a> {}
-impl<'a> Parse<'a> for ContentParticle<'a> {
+impl<'a> ParseNamespace<'a> for ContentParticle {}
+impl<'a> Parse<'a> for ContentParticle {
     type Args = ();
     type Output = IResult<&'a str, Self>;
 
@@ -58,9 +58,9 @@ impl<'a> Parse<'a> for ContentParticle<'a> {
     }
 }
 
-impl<'a> ContentParticle<'a> {
+impl ContentParticle {
     // [49] choice ::= '(' S? cp ( S? '|' S? cp )+ S? ')'
-    pub fn parse_choice(input: &'a str) -> IResult<&'a str, Vec<ContentParticle<'a>>> {
+    pub fn parse_choice(input: &str) -> IResult<&str, Vec<ContentParticle>> {
         map(
             delimited(
                 tuple((char('('), Self::parse_multispace0)),
@@ -83,7 +83,7 @@ impl<'a> ContentParticle<'a> {
     }
 
     // [50] seq ::= '(' S? cp ( S? ',' S? cp )* S? ')'
-    pub fn parse_sequence(input: &'a str) -> IResult<&'a str, Vec<ContentParticle<'a>>> {
+    pub fn parse_sequence(input: &str) -> IResult<&str, Vec<ContentParticle>> {
         delimited(
             tuple((char('('), Self::parse_multispace0)),
             separated_list0(

--- a/src/prolog/declaration_content.rs
+++ b/src/prolog/declaration_content.rs
@@ -11,14 +11,14 @@ use nom::{
 use super::content_particle::ContentParticle;
 
 #[derive(Clone, PartialEq)]
-pub enum DeclarationContent<'a> {
-    Mixed(Mixed<'a>),
-    Children(ContentParticle<'a>),
+pub enum DeclarationContent {
+    Mixed(Mixed),
+    Children(ContentParticle),
     Empty,
     Any,
 }
 
-impl<'a> Parse<'a> for DeclarationContent<'a> {
+impl<'a> Parse<'a> for DeclarationContent {
     type Args = ();
     type Output = IResult<&'a str, Self>;
     // [46] contentspec ::= 'EMPTY' | 'ANY' | Mixed | children
@@ -31,9 +31,9 @@ impl<'a> Parse<'a> for DeclarationContent<'a> {
         ))(input)
     }
 }
-impl<'a> DeclarationContent<'a> {
+impl DeclarationContent {
     // [47] children ::= (choice | seq) ('?' | '*' | '+')?
-    fn parse_children(input: &'a str) -> IResult<&'a str, ContentParticle<'a>> {
+    fn parse_children(input: &str) -> IResult<&str, ContentParticle> {
         let (input, particle) = alt((
             map(
                 tuple((
@@ -59,14 +59,14 @@ impl<'a> DeclarationContent<'a> {
 }
 
 #[derive(Clone, PartialEq)]
-pub enum Mixed<'a> {
+pub enum Mixed {
     PCDATA {
-        names: Option<Vec<QualifiedName<'a>>>,
+        names: Option<Vec<QualifiedName>>,
         parsed: bool,
     },
 }
-impl<'a> ParseNamespace<'a> for Mixed<'a> {}
-impl<'a> Parse<'a> for Mixed<'a> {
+impl<'a> ParseNamespace<'a> for Mixed {}
+impl<'a> Parse<'a> for Mixed {
     type Args = ();
     type Output = IResult<&'a str, Self>;
     // [51] Mixed ::= '(' S? '#PCDATA' (S? '|' S? Name)* S? ')*' | '(' S? '#PCDATA' S? ')'

--- a/src/prolog/doctype.rs
+++ b/src/prolog/doctype.rs
@@ -21,14 +21,14 @@ use super::{
 };
 
 #[derive(Clone, PartialEq)]
-pub struct DocType<'a> {
-    pub name: Name<'a>,
-    pub external_id: Option<ExternalID<'a>>,
-    pub int_subset: Option<Vec<InternalSubset<'a>>>,
+pub struct DocType {
+    pub name: Name,
+    pub external_id: Option<ExternalID>,
+    pub int_subset: Option<Vec<InternalSubset>>,
 }
 
-impl<'a> Parse<'a> for DocType<'a> {
-    type Args = Rc<RefCell<HashMap<Name<'a>, EntityValue<'a>>>>;
+impl<'a> Parse<'a> for DocType {
+    type Args = Rc<RefCell<HashMap<Name, EntityValue>>>;
 
     type Output = IResult<&'a str, Self>;
 
@@ -102,8 +102,8 @@ impl<'a> Parse<'a> for DocType<'a> {
 }
 
 //TODO integrate this
-impl<'a> DocType<'a> {
-    pub fn get_entities(&self) -> InternalSubset<'a> {
+impl DocType {
+    pub fn get_entities(&self) -> InternalSubset {
         let entities: Vec<_> = self.int_subset.as_ref().map_or(Vec::new(), |subset| {
             subset
                 .iter()
@@ -121,9 +121,9 @@ impl<'a> DocType<'a> {
     }
     //TODO: figure out how to integrate this or remove
     fn _parse_qualified_doctype(
-        input: &'a str,
-        entity_references: Rc<RefCell<HashMap<Name<'a>, EntityValue<'a>>>>,
-    ) -> IResult<&'a str, DocType<'a>> {
+        input: &str,
+        entity_references: Rc<RefCell<HashMap<Name, EntityValue>>>,
+    ) -> IResult<&str, DocType> {
         let (input, _) = tag("<!DOCTYPE")(input)?;
         let (input, _) = Self::parse_multispace1(input)?;
         let (input, name) = Self::parse_qualified_name(input)?;
@@ -155,4 +155,4 @@ impl<'a> DocType<'a> {
     }
 }
 
-impl<'a> ParseNamespace<'a> for DocType<'a> {}
+impl<'a> ParseNamespace<'a> for DocType {}

--- a/src/prolog/external_id.rs
+++ b/src/prolog/external_id.rs
@@ -11,15 +11,15 @@ use std::borrow::Cow;
 use super::id::ID;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum ExternalID<'a> {
-    System(Cow<'a, str>),
+pub enum ExternalID {
+    System(String),
     Public {
-        pubid: Cow<'a, str>,
-        system_identifier: Box<ExternalID<'a>>, // Box<ExternalID::System>
+        pubid: String,
+        system_identifier: Box<ExternalID>, // Box<ExternalID::System>
     },
 }
 
-impl<'a> Parse<'a> for ExternalID<'a> {
+impl<'a> Parse<'a> for ExternalID {
     type Args = ();
     type Output = IResult<&'a str, Self>;
     //[75] ExternalID ::= 'SYSTEM' S SystemLiteral | 'PUBLIC' S PubidLiteral S SystemLiteral
@@ -28,8 +28,8 @@ impl<'a> Parse<'a> for ExternalID<'a> {
     }
 }
 
-impl<'a> ExternalID<'a> {
-    fn parse_system(input: &'a str) -> IResult<&'a str, ExternalID<'a>> {
+impl ExternalID {
+    fn parse_system(input: &str) -> IResult<&str, ExternalID> {
         map(
             tuple((
                 tag("SYSTEM"),
@@ -40,7 +40,7 @@ impl<'a> ExternalID<'a> {
         )(input)
     }
 
-    fn parse_public(input: &'a str) -> IResult<&'a str, ExternalID<'a>> {
+    fn parse_public(input: &str) -> IResult<&str, ExternalID> {
         map(
             tuple((
                 tag("PUBLIC"),
@@ -59,13 +59,13 @@ impl<'a> ExternalID<'a> {
     }
 
     // [11] SystemLiteral ::= ('"' [^"]* '"') | ("'" [^']* "'")
-    fn parse_system_literal(input: &'a str) -> IResult<&'a str, Cow<'a, str>> {
+    fn parse_system_literal(input: &str) -> IResult<&str, String> {
         map(
             alt((
                 delimited(tag("\""), is_not("\""), tag("\"")),
                 delimited(tag("'"), is_not("'"), tag("'")),
             )),
-            Cow::Borrowed,
+            |s: &str| s.to_string(),
         )(input)
     }
 }

--- a/src/prolog/id.rs
+++ b/src/prolog/id.rs
@@ -15,12 +15,12 @@ use crate::parse::Parse;
 use super::external_id::ExternalID;
 
 #[derive(Clone, PartialEq)]
-pub enum ID<'a> {
-    ExternalID(ExternalID<'a>),
-    PublicID(Cow<'a, str>),
+pub enum ID {
+    ExternalID(ExternalID),
+    PublicID(String),
 }
 
-impl<'a> Parse<'a> for ID<'a> {
+impl<'a> Parse<'a> for ID {
     type Args = ();
     type Output = IResult<&'a str, Self>;
     // [83] PublicID ::= 'PUBLIC' S PubidLiteral
@@ -38,9 +38,9 @@ impl<'a> Parse<'a> for ID<'a> {
     }
 }
 
-impl<'a> ID<'a> {
+impl ID {
     // [12] PubidLiteral ::= '"' PubidChar* '"' | "'" (PubidChar - "'")* "'"
-    pub fn parse_public_id_literal(input: &'a str) -> IResult<&'a str, Cow<'a, str>> {
+    pub fn parse_public_id_literal(input: &str) -> IResult<&str, String> {
         map(
             alt((
                 delimited(
@@ -54,15 +54,12 @@ impl<'a> ID<'a> {
                     tag("'"),
                 ),
             )),
-            |pubid_literal: Vec<&'a str>| Cow::Owned(pubid_literal.concat()),
+            |pubid_literal: Vec<&str>| pubid_literal.concat(),
         )(input)
     }
 
     // [13] PubidChar ::= #x20 | #xD | #xA | [a-zA-Z0-9] | [-'()+,./:=?;!*#@$_%]
-    pub fn parse_pubid_char(
-        input: &'a str,
-        exclude_single_quote: bool,
-    ) -> IResult<&'a str, &'a str> {
+    pub fn parse_pubid_char(input: &str, exclude_single_quote: bool) -> IResult<&str, &str> {
         let chars = if exclude_single_quote {
             " \r\n-()+,./:=?;!*#@$_%"
         } else {

--- a/src/prolog/internal_subset/entity_declaration.rs
+++ b/src/prolog/internal_subset/entity_declaration.rs
@@ -3,21 +3,21 @@ use crate::{prolog::external_id::ExternalID, Name};
 use super::{entity_definition::EntityDefinition, entity_value::EntityValue};
 
 #[derive(Clone, PartialEq)]
-pub enum EntityDecl<'a> {
-    General(GeneralEntityDeclaration<'a>),
-    Parameter(ParameterEntityDeclaration<'a>),
+pub enum EntityDecl {
+    General(GeneralEntityDeclaration),
+    Parameter(ParameterEntityDeclaration),
 }
 
 #[derive(Clone, PartialEq)]
-pub struct EntityDeclaration<'a> {
-    pub name: Name<'a>,
-    pub entity_def: EntityDefinition<'a>,
+pub struct EntityDeclaration {
+    pub name: Name,
+    pub entity_def: EntityDefinition,
 }
-pub type GeneralEntityDeclaration<'a> = EntityDeclaration<'a>;
-pub type ParameterEntityDeclaration<'a> = EntityDeclaration<'a>;
+pub type GeneralEntityDeclaration = EntityDeclaration;
+pub type ParameterEntityDeclaration = EntityDeclaration;
 
-impl<'a> EntityDeclaration<'a> {
-    pub fn find_name(&self, name: Name<'a>) -> Option<&GeneralEntityDeclaration<'a>> {
+impl EntityDeclaration {
+    pub fn find_name(&self, name: Name) -> Option<&GeneralEntityDeclaration> {
         if self.name == name {
             Some(self)
         } else {
@@ -25,11 +25,11 @@ impl<'a> EntityDeclaration<'a> {
         }
     }
 
-    pub fn get_name(&self) -> &Name<'a> {
+    pub fn get_name(&self) -> &Name {
         &self.name
     }
 
-    pub fn get_entity_def(&self) -> &EntityDefinition<'a> {
+    pub fn get_entity_def(&self) -> &EntityDefinition {
         &self.entity_def
     }
 }

--- a/src/prolog/internal_subset/entity_definition.rs
+++ b/src/prolog/internal_subset/entity_definition.rs
@@ -3,16 +3,16 @@ use crate::{prolog::external_id::ExternalID, Name};
 use super::entity_value::EntityValue;
 
 #[derive(Clone, PartialEq)]
-pub enum EntityDefinition<'a> {
-    EntityValue(EntityValue<'a>),
+pub enum EntityDefinition {
+    EntityValue(EntityValue),
     External {
-        id: ExternalID<'a>,
-        n_data: Option<Name<'a>>,
+        id: ExternalID,
+        n_data: Option<Name>,
     },
 }
 
-impl<'a> EntityDefinition<'a> {
-    pub fn get_entity_value(&self) -> Option<&EntityValue<'a>> {
+impl EntityDefinition {
+    pub fn get_entity_value(&self) -> Option<&EntityValue> {
         if let EntityDefinition::EntityValue(value) = self {
             Some(value)
         } else {
@@ -20,7 +20,7 @@ impl<'a> EntityDefinition<'a> {
         }
     }
 
-    pub fn get_external_id(&self) -> Option<&ExternalID<'a>> {
+    pub fn get_external_id(&self) -> Option<&ExternalID> {
         if let EntityDefinition::External { id, .. } = self {
             Some(id)
         } else {

--- a/src/prolog/internal_subset/entity_value.rs
+++ b/src/prolog/internal_subset/entity_value.rs
@@ -7,23 +7,23 @@ use crate::{reference::Reference, Document};
 use super::InternalSubset;
 
 #[derive(Clone, PartialEq)]
-pub enum EntityValue<'a> {
-    Document(Document<'a>),
-    Value(Cow<'a, str>),
-    Reference(Reference<'a>),
-    ParameterReference(Reference<'a>),
-    InternalSubset(Box<InternalSubset<'a>>),
+pub enum EntityValue {
+    Document(Document),
+    Value(String),
+    Reference(Reference),
+    ParameterReference(Reference),
+    InternalSubset(Box<InternalSubset>),
 }
 
-impl<'a> EntityValue<'a> {
-    pub fn get_value(&self) -> Option<Cow<'a, str>> {
+impl EntityValue {
+    pub fn get_value(&self) -> Option<String> {
         match self {
             EntityValue::Value(value) => Some(value.clone()),
             _ => None,
         }
     }
 
-    pub fn get_reference(&self) -> Option<&Reference<'a>> {
+    pub fn get_reference(&self) -> Option<&Reference> {
         if let EntityValue::Reference(reference) = self {
             Some(reference)
         } else {
@@ -31,7 +31,7 @@ impl<'a> EntityValue<'a> {
         }
     }
 
-    pub fn get_perameter_reference(&self) -> Option<&Reference<'a>> {
+    pub fn get_perameter_reference(&self) -> Option<&Reference> {
         if let EntityValue::ParameterReference(reference) = self {
             Some(reference)
         } else {

--- a/src/prolog/xmldecl.rs
+++ b/src/prolog/xmldecl.rs
@@ -30,12 +30,12 @@ impl FromStr for Standalone {
 }
 
 #[derive(Clone, PartialEq)]
-pub struct XmlDecl<'a> {
-    pub version: Cow<'a, str>,
-    pub encoding: Option<Cow<'a, str>>,
+pub struct XmlDecl {
+    pub version: String,
+    pub encoding: Option<String>,
     pub standalone: Option<Standalone>,
 }
-impl<'a> Parse<'a> for XmlDecl<'a> {
+impl<'a> Parse<'a> for XmlDecl {
     type Args = ();
     type Output = IResult<&'a str, Self>;
     // [23] XMLDecl	::=  '<?xml' VersionInfo EncodingDecl? SDDecl? S? '?>'
@@ -58,9 +58,9 @@ impl<'a> Parse<'a> for XmlDecl<'a> {
     }
 }
 
-impl<'a> XmlDecl<'a> {
+impl XmlDecl {
     // [24] VersionInfo	::= S 'version' Eq ("'" VersionNum "'" | '"' VersionNum '"')
-    fn parse_version_info(input: &'a str) -> IResult<&'a str, Cow<'a, str>> {
+    fn parse_version_info(input: &str) -> IResult<&str, String> {
         map(
             tuple((
                 Self::parse_multispace1,
@@ -76,13 +76,13 @@ impl<'a> XmlDecl<'a> {
     }
 
     // [26] VersionNum	::= '1.' [0-9]+
-    fn parse_version_num(input: &'a str) -> IResult<&'a str, Cow<'a, str>> {
+    fn parse_version_num(input: &str) -> IResult<&str, String> {
         map(preceded(tag("1."), digit1), |version| {
-            format!("1.{}", version).into()
+            format!("1.{}", version)
         })(input)
     }
     // [80] EncodingDecl	::= S 'encoding' Eq ('"' EncName '"' | "'" EncName "'" )
-    fn parse_encoding_decl(input: &'a str) -> IResult<&'a str, Cow<'a, str>> {
+    fn parse_encoding_decl(input: &str) -> IResult<&str, String> {
         map(
             tuple((
                 Self::parse_multispace1,
@@ -98,18 +98,18 @@ impl<'a> XmlDecl<'a> {
     }
 
     // [81] EncName	::= [A-Za-z] ([A-Za-z0-9._] | '-')*
-    fn parse_enc_name(input: &'a str) -> IResult<&'a str, Cow<'a, str>> {
+    fn parse_enc_name(input: &str) -> IResult<&str, String> {
         map(
             pair(
                 alt((alpha1, tag("-"))),
                 many0(alt((alphanumeric1, tag("."), tag("_"), tag("-")))),
             ),
-            |(first, rest)| format!("{}{}", first, rest.join("")).into(),
+            |(first, rest)| format!("{}{}", first, rest.join("")),
         )(input)
     }
 
     // [32] SDDecl	::= S 'standalone' Eq (("'" ('yes' | 'no') "'") | ('"' ('yes' | 'no') '"'))
-    fn parse_sd_decl(input: &'a str) -> IResult<&'a str, Standalone> {
+    fn parse_sd_decl(input: &str) -> IResult<&str, Standalone> {
         map(
             tuple((
                 Self::parse_multispace1,

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -22,27 +22,27 @@ pub enum TagState {
 }
 
 #[derive(Clone, PartialEq)]
-pub struct Tag<'a> {
-    pub name: Name<'a>,
-    pub attributes: Option<Vec<Attribute<'a>>>, // Attribute::Instance
+pub struct Tag {
+    pub name: Name,
+    pub attributes: Option<Vec<Attribute>>, // Attribute::Instance
     pub state: TagState,
 }
 
-impl<'a> Parse<'a> for Tag<'a> {
+impl<'a> Parse<'a> for Tag {
     type Args = ();
     type Output = IResult<&'a str, Self>;
 }
-impl<'a> ParseNamespace<'a> for Tag<'a> {}
+impl<'a> ParseNamespace<'a> for Tag {}
 
 // TODO: Investigate. The hardcoded bracket codes is kind of a hack to get reference element parsing to work. Unsure of how this is going to impact invalid XML.
 // Tried to use decode, but having some lifetime issues
-impl<'a> Tag<'a> {
+impl Tag {
     // [40] STag ::= '<' Name (S Attribute)* S? '>'
     // Namespaces (Third Edition) [12] STag ::= '<' QName (S Attribute)* S? '>'
     pub fn parse_start_tag(
-        input: &'a str,
-        entity_references: Rc<RefCell<HashMap<Name<'a>, EntityValue<'a>>>>,
-    ) -> IResult<&'a str, Self> {
+        input: &str,
+        entity_references: Rc<RefCell<HashMap<Name, EntityValue>>>,
+    ) -> IResult<&str, Self> {
         map(
             tuple((
                 alt((tag("&#60;"), tag("&#x3C;"), tag("<"))),
@@ -74,7 +74,7 @@ impl<'a> Tag<'a> {
 
     // [42] ETag ::= '</' Name S? '>'
     // Namespaces (Third Edition) [13] ETag ::= '</' QName S? '>'
-    pub fn parse_end_tag(input: &'a str) -> IResult<&'a str, Self> {
+    pub fn parse_end_tag(input: &str) -> IResult<&str, Self> {
         delimited(
             alt((tag("&#60;/"), tag("&#x3C;/"), tag("</"))),
             map(
@@ -96,9 +96,9 @@ impl<'a> Tag<'a> {
     // [44] EmptyElemTag ::= '<' Name (S Attribute)* S? '/>'
     // Namespaces (Third Edition) [14] EmptyElemTag ::= '<' QName (S Attribute)* S? '/>'
     pub fn parse_empty_element_tag(
-        input: &'a str,
-        entity_references: Rc<RefCell<HashMap<Name<'a>, EntityValue<'a>>>>,
-    ) -> IResult<&'a str, Tag<'a>> {
+        input: &str,
+        entity_references: Rc<RefCell<HashMap<Name, EntityValue>>>,
+    ) -> IResult<&str, Tag> {
         map(
             tuple((
                 alt((tag("&#60;"), tag("&#x3C;"), tag("<"))),

--- a/tests/valid_sa_compliance.rs
+++ b/tests/valid_sa_compliance.rs
@@ -25,20 +25,16 @@ use nom_xml::{
 };
 use std::{borrow::Cow, error::Error, fs::File};
 
-fn test_valid_sa_file<'a>(
-    file_number: &str,
-    buffer: &'a mut String,
-) -> Result<Document<'a>, Box<dyn Error>> {
+fn test_valid_sa_file(file_number: &str) -> Result<Document, Box<dyn Error>> {
     let mut file = File::open(format!("tests/xmltest/valid/sa/{file_number}.xml"))?;
 
-    let document = parse_file(&mut file, buffer)?;
+    let document = parse_file(&mut file)?;
     Ok(document)
 }
 
 #[test]
 fn test_valid_sa_001() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("001", &mut buffer)?;
+    let document = test_valid_sa_file("001")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -77,8 +73,7 @@ fn test_valid_sa_001() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_002() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("002", &mut buffer)?;
+    let document = test_valid_sa_file("002")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -117,8 +112,7 @@ fn test_valid_sa_002() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_003() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("003", &mut buffer)?;
+    let document = test_valid_sa_file("003")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -157,8 +151,7 @@ fn test_valid_sa_003() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_004() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("004", &mut buffer)?;
+    let document = test_valid_sa_file("004")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -192,7 +185,7 @@ fn test_valid_sa_004() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a1"),
-                        value: AttributeValue::Value("v1".into()),
+                        value: AttributeValue::Value("v1".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -210,8 +203,7 @@ fn test_valid_sa_004() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_005() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("005", &mut buffer)?;
+    let document = test_valid_sa_file("005")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -245,7 +237,7 @@ fn test_valid_sa_005() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a1"),
-                        value: AttributeValue::Value("v1".into()),
+                        value: AttributeValue::Value("v1".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -263,8 +255,7 @@ fn test_valid_sa_005() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_006() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("006", &mut buffer)?;
+    let document = test_valid_sa_file("006")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -298,7 +289,7 @@ fn test_valid_sa_006() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a1"),
-                        value: AttributeValue::Value("v1".into()),
+                        value: AttributeValue::Value("v1".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -316,8 +307,7 @@ fn test_valid_sa_006() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_007() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("007", &mut buffer)?;
+    let document = test_valid_sa_file("007")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -342,7 +332,7 @@ fn test_valid_sa_007() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Owned(" ".into())))),
+                Box::new(Document::Content(Some(" ".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -356,8 +346,7 @@ fn test_valid_sa_007() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_008() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("008", &mut buffer)?;
+    let document = test_valid_sa_file("008")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -382,7 +371,7 @@ fn test_valid_sa_008() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Owned("&<>\"'".into())))),
+                Box::new(Document::Content(Some("&<>\"'".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -396,8 +385,7 @@ fn test_valid_sa_008() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_009() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("009", &mut buffer)?;
+    let document = test_valid_sa_file("009")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -422,7 +410,7 @@ fn test_valid_sa_009() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Owned(" ".into())))),
+                Box::new(Document::Content(Some(" ".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -436,8 +424,7 @@ fn test_valid_sa_009() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_010() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("010", &mut buffer)?;
+    let document = test_valid_sa_file("010")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -471,7 +458,7 @@ fn test_valid_sa_010() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a1"),
-                        value: AttributeValue::Value("v1".into()),
+                        value: AttributeValue::Value("v1".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -488,8 +475,7 @@ fn test_valid_sa_010() -> Result<(), Box<dyn Error>> {
 }
 #[test]
 fn test_valid_sa_011() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("011", &mut buffer)?;
+    let document = test_valid_sa_file("011")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -531,11 +517,11 @@ fn test_valid_sa_011() -> Result<(), Box<dyn Error>> {
                     attributes: Some(vec![
                         Attribute::Instance {
                             name: QualifiedName::new(None, "a1"),
-                            value: AttributeValue::Value("v1".into()),
+                            value: AttributeValue::Value("v1".to_string()),
                         },
                         Attribute::Instance {
                             name: QualifiedName::new(None, "a2"),
-                            value: AttributeValue::Value("v2".into()),
+                            value: AttributeValue::Value("v2".to_string()),
                         },
                     ]),
                     state: TagState::Start,
@@ -554,8 +540,7 @@ fn test_valid_sa_011() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_012() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("012", &mut buffer)?;
+    let document = test_valid_sa_file("012")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -589,7 +574,7 @@ fn test_valid_sa_012() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, ":"), // TODO: confirm this is correct
-                        value: AttributeValue::Value("v1".into()),
+                        value: AttributeValue::Value("v1".to_string()),
                     },]),
                     state: TagState::Start,
                 },
@@ -607,8 +592,7 @@ fn test_valid_sa_012() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_013() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("013", &mut buffer)?;
+    let document = test_valid_sa_file("013")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -642,7 +626,7 @@ fn test_valid_sa_013() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "_.-0123456789"),
-                        value: AttributeValue::Value("v1".into()),
+                        value: AttributeValue::Value("v1".to_string()),
                     },]),
                     state: TagState::Start,
                 },
@@ -660,8 +644,7 @@ fn test_valid_sa_013() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_014() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("014", &mut buffer)?;
+    let document = test_valid_sa_file("014")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -695,7 +678,7 @@ fn test_valid_sa_014() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "abcdefghijklmnopqrstuvwxyz"),
-                        value: AttributeValue::Value("v1".into()),
+                        value: AttributeValue::Value("v1".to_string()),
                     },]),
                     state: TagState::Start,
                 },
@@ -713,8 +696,7 @@ fn test_valid_sa_014() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_015() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("015", &mut buffer)?;
+    let document = test_valid_sa_file("015")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -748,7 +730,7 @@ fn test_valid_sa_015() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
-                        value: AttributeValue::Value("v1".into()),
+                        value: AttributeValue::Value("v1".to_string()),
                     },]),
                     state: TagState::Start,
                 },
@@ -766,8 +748,7 @@ fn test_valid_sa_015() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_016() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("016", &mut buffer)?;
+    let document = test_valid_sa_file("016")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -809,8 +790,7 @@ fn test_valid_sa_016() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_017() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("017", &mut buffer)?;
+    let document = test_valid_sa_file("017")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -838,7 +818,7 @@ fn test_valid_sa_017() -> Result<(), Box<dyn Error>> {
                 Box::new(Document::Nested(vec![
                     Document::ProcessingInstruction(ProcessingInstruction {
                         target: QualifiedName::new(None, "pi"),
-                        data: Some("some data ".into()),
+                        data: Some("some data ".to_string()),
                     }),
                     Document::ProcessingInstruction(ProcessingInstruction {
                         target: QualifiedName::new(None, "x"),
@@ -858,8 +838,7 @@ fn test_valid_sa_017() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_017a() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("017a", &mut buffer)?;
+    let document = test_valid_sa_file("017a")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -886,7 +865,7 @@ fn test_valid_sa_017a() -> Result<(), Box<dyn Error>> {
                 },
                 Box::new(Document::ProcessingInstruction(ProcessingInstruction {
                     target: QualifiedName::new(None, "pi"),
-                    data: Some("some data ? > <?".into()),
+                    data: Some("some data ? > <?".to_string()),
                 })),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
@@ -901,8 +880,7 @@ fn test_valid_sa_017a() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_018() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("018", &mut buffer)?;
+    let document = test_valid_sa_file("018")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -927,7 +905,7 @@ fn test_valid_sa_018() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::CDATA("<foo>".into())),
+                Box::new(Document::CDATA("<foo>".to_string())),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -941,8 +919,7 @@ fn test_valid_sa_018() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_019() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("019", &mut buffer)?;
+    let document = test_valid_sa_file("019")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -967,7 +944,7 @@ fn test_valid_sa_019() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::CDATA("<&".into())),
+                Box::new(Document::CDATA("<&".to_string())),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -981,8 +958,7 @@ fn test_valid_sa_019() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_020() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("020", &mut buffer)?;
+    let document = test_valid_sa_file("020")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1007,7 +983,7 @@ fn test_valid_sa_020() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::CDATA("<&]>]".into())),
+                Box::new(Document::CDATA("<&]>]".to_string())),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -1021,8 +997,7 @@ fn test_valid_sa_020() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_021() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("021", &mut buffer)?;
+    let document = test_valid_sa_file("021")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1047,7 +1022,7 @@ fn test_valid_sa_021() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Comment(" a comment ".into())),
+                Box::new(Document::Comment(" a comment ".to_string())),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -1061,8 +1036,7 @@ fn test_valid_sa_021() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_022() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("022", &mut buffer)?;
+    let document = test_valid_sa_file("022")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1087,7 +1061,7 @@ fn test_valid_sa_022() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Comment(" a comment ->".into())),
+                Box::new(Document::Comment(" a comment ->".to_string())),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -1101,8 +1075,7 @@ fn test_valid_sa_022() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_023() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("023", &mut buffer)?;
+    let document = test_valid_sa_file("023")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1123,7 +1096,7 @@ fn test_valid_sa_023() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "".into()
+                                "".to_string()
                             )),
                         })),
                     ]),
@@ -1135,7 +1108,7 @@ fn test_valid_sa_023() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some("".into()))),
+                Box::new(Document::Content(Some("".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -1149,8 +1122,7 @@ fn test_valid_sa_023() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_024() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("024", &mut buffer)?;
+    let document = test_valid_sa_file("024")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1183,7 +1155,7 @@ fn test_valid_sa_024() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "&#60;foo></foo>".into()
+                                "&#60;foo></foo>".to_string()
                             )),
                         })),
                     ]),
@@ -1221,8 +1193,7 @@ fn test_valid_sa_024() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_025() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("025", &mut buffer)?;
+    let document = test_valid_sa_file("025")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1294,8 +1265,7 @@ fn test_valid_sa_025() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_026() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("026", &mut buffer)?;
+    let document = test_valid_sa_file("026")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1364,8 +1334,7 @@ fn test_valid_sa_026() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_027() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("027", &mut buffer)?;
+    let document = test_valid_sa_file("027")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1434,14 +1403,13 @@ fn test_valid_sa_027() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_028() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("028", &mut buffer)?;
+    let document = test_valid_sa_file("028")?;
     assert_eq!(
         document,
         Document::Nested(vec![
             Document::Prolog {
                 xml_decl: Some(XmlDecl {
-                    version: Cow::Borrowed("1.0"),
+                    version: "1.0".to_string(),
                     encoding: None,
                     standalone: None,
                 }),
@@ -1478,14 +1446,13 @@ fn test_valid_sa_028() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_029() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("029", &mut buffer)?;
+    let document = test_valid_sa_file("029")?;
     assert_eq!(
         document,
         Document::Nested(vec![
             Document::Prolog {
                 xml_decl: Some(XmlDecl {
-                    version: Cow::Borrowed("1.0"),
+                    version: "1.0".to_string(),
                     encoding: None,
                     standalone: None,
                 }),
@@ -1522,14 +1489,13 @@ fn test_valid_sa_029() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_030() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("030", &mut buffer)?;
+    let document = test_valid_sa_file("030")?;
     assert_eq!(
         document,
         Document::Nested(vec![
             Document::Prolog {
                 xml_decl: Some(XmlDecl {
-                    version: Cow::Borrowed("1.0"),
+                    version: "1.0".to_string(),
                     encoding: None,
                     standalone: None,
                 }),
@@ -1566,15 +1532,14 @@ fn test_valid_sa_030() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_031() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("031", &mut buffer)?;
+    let document = test_valid_sa_file("031")?;
     assert_eq!(
         document,
         Document::Nested(vec![
             Document::Prolog {
                 xml_decl: Some(XmlDecl {
-                    version: Cow::Borrowed("1.0"),
-                    encoding: Some(Cow::Borrowed("UTF-8")),
+                    version: "1.0".to_string(),
+                    encoding: Some("UTF-8".to_string()),
                     standalone: None,
                 }),
                 misc: None,
@@ -1610,14 +1575,13 @@ fn test_valid_sa_031() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_032() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("032", &mut buffer)?;
+    let document = test_valid_sa_file("032")?;
     assert_eq!(
         document,
         Document::Nested(vec![
             Document::Prolog {
                 xml_decl: Some(XmlDecl {
-                    version: Cow::Borrowed("1.0"),
+                    version: "1.0".to_string(),
                     encoding: None,
                     standalone: Some(Standalone::Yes),
                 }),
@@ -1654,15 +1618,14 @@ fn test_valid_sa_032() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_033() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("033", &mut buffer)?;
+    let document = test_valid_sa_file("033")?;
     assert_eq!(
         document,
         Document::Nested(vec![
             Document::Prolog {
                 xml_decl: Some(XmlDecl {
-                    version: Cow::Borrowed("1.0"),
-                    encoding: Some(Cow::Borrowed("UTF-8")),
+                    version: "1.0".to_string(),
+                    encoding: Some("UTF-8".to_string()),
                     standalone: Some(Standalone::Yes),
                 }),
                 misc: None,
@@ -1698,8 +1661,7 @@ fn test_valid_sa_033() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_034() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("034", &mut buffer)?;
+    let document = test_valid_sa_file("034")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1730,8 +1692,7 @@ fn test_valid_sa_034() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_035() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("035", &mut buffer)?;
+    let document = test_valid_sa_file("035")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1762,8 +1723,7 @@ fn test_valid_sa_035() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_036() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("036", &mut buffer)?;
+    let document = test_valid_sa_file("036")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1797,7 +1757,7 @@ fn test_valid_sa_036() -> Result<(), Box<dyn Error>> {
             ),
             Document::ProcessingInstruction(ProcessingInstruction {
                 target: QualifiedName::new(None, "pi"),
-                data: Some("data".into()),
+                data: Some("data".to_string()),
             }),
         ]),
     );
@@ -1806,8 +1766,7 @@ fn test_valid_sa_036() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_037() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("037", &mut buffer)?;
+    let document = test_valid_sa_file("037")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1839,7 +1798,7 @@ fn test_valid_sa_037() -> Result<(), Box<dyn Error>> {
                     state: TagState::End,
                 }
             ),
-            Document::Comment(" comment ".into()),
+            Document::Comment(" comment ".to_string()),
         ]),
     );
     Ok(())
@@ -1847,8 +1806,7 @@ fn test_valid_sa_037() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_038() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("038", &mut buffer)?;
+    let document = test_valid_sa_file("038")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1856,7 +1814,7 @@ fn test_valid_sa_038() -> Result<(), Box<dyn Error>> {
                 xml_decl: None,
                 misc: Some(vec![Misc {
                     content: Box::new(Document::Nested(vec![Document::Comment(
-                        " comment ".into()
+                        " comment ".to_string()
                     )])),
                     state: MiscState::BeforeDoctype,
                 },]),
@@ -1892,8 +1850,7 @@ fn test_valid_sa_038() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_039() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("039", &mut buffer)?;
+    let document = test_valid_sa_file("039")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1903,7 +1860,7 @@ fn test_valid_sa_039() -> Result<(), Box<dyn Error>> {
                     content: Box::new(Document::Nested(vec![Document::ProcessingInstruction(
                         ProcessingInstruction {
                             target: QualifiedName::new(None, "pi"),
-                            data: Some("data".into()),
+                            data: Some("data".to_string()),
                         },
                     )])),
                     state: MiscState::BeforeDoctype,
@@ -1940,8 +1897,7 @@ fn test_valid_sa_039() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_040() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("040", &mut buffer)?;
+    let document = test_valid_sa_file("040")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -1975,7 +1931,7 @@ fn test_valid_sa_040() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a1"),
-                        value: AttributeValue::Value("\"<&>'".into()), // using .into() instead of Cow::Borrowed
+                        value: AttributeValue::Value("\"<&>'".to_string()), // using .into() instead of Cow::Borrowed
                     },]),
                     state: TagState::Start,
                 },
@@ -1993,8 +1949,7 @@ fn test_valid_sa_040() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_041() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("041", &mut buffer)?;
+    let document = test_valid_sa_file("041")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2028,7 +1983,7 @@ fn test_valid_sa_041() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a1"),
-                        value: AttributeValue::Value("A".into()), // '&#65;' decodes to 'A'
+                        value: AttributeValue::Value("A".to_string()), // '&#65;' decodes to 'A'
                     },]),
                     state: TagState::Start,
                 },
@@ -2046,8 +2001,7 @@ fn test_valid_sa_041() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_042() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("042", &mut buffer)?;
+    let document = test_valid_sa_file("042")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2072,7 +2026,7 @@ fn test_valid_sa_042() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Borrowed("A")))), // '&#00000000000000000000000000000000065;' decodes to 'A'
+                Box::new(Document::Content(Some("A".to_string()))), // '&#00000000000000000000000000000000065;' decodes to 'A'
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -2086,8 +2040,7 @@ fn test_valid_sa_042() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_043() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("043", &mut buffer)?;
+    let document = test_valid_sa_file("043")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2121,7 +2074,7 @@ fn test_valid_sa_043() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a1"),
-                        value: AttributeValue::Value("foo\nbar".into()), // attribute value spans multiple lines
+                        value: AttributeValue::Value("foo\nbar".to_string()), // attribute value spans multiple lines
                     },]),
                     state: TagState::Start,
                 },
@@ -2139,8 +2092,7 @@ fn test_valid_sa_043() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_044() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("044", &mut buffer)?;
+    let document = test_valid_sa_file("044")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2173,12 +2125,12 @@ fn test_valid_sa_044() -> Result<(), Box<dyn Error>> {
                                 Attribute::Definition {
                                     name: QualifiedName::new(None, "a1"),
                                     att_type: AttType::CDATA,
-                                    default_decl: DefaultDecl::Value("v1".into()),
+                                    default_decl: DefaultDecl::Value("v1".to_string()),
                                 },
                                 Attribute::Definition {
                                     name: QualifiedName::new(None, "a2"),
                                     att_type: AttType::CDATA,
-                                    default_decl: DefaultDecl::Value("v2".into()),
+                                    default_decl: DefaultDecl::Value("v2".to_string()),
                                 },
                                 Attribute::Definition {
                                     name: QualifiedName::new(None, "a3"),
@@ -2201,7 +2153,7 @@ fn test_valid_sa_044() -> Result<(), Box<dyn Error>> {
                         name: QualifiedName::new(None, "e"),
                         attributes: Some(vec![Attribute::Instance {
                             name: QualifiedName::new(None, "a3"),
-                            value: AttributeValue::Value("v3".into()),
+                            value: AttributeValue::Value("v3".to_string()),
                         }]),
                         state: TagState::Empty,
                     }),
@@ -2209,7 +2161,7 @@ fn test_valid_sa_044() -> Result<(), Box<dyn Error>> {
                         name: QualifiedName::new(None, "e"),
                         attributes: Some(vec![Attribute::Instance {
                             name: QualifiedName::new(None, "a1"),
-                            value: AttributeValue::Value("w1".into()),
+                            value: AttributeValue::Value("w1".to_string()),
                         }]),
                         state: TagState::Empty,
                     }),
@@ -2218,11 +2170,11 @@ fn test_valid_sa_044() -> Result<(), Box<dyn Error>> {
                         attributes: Some(vec![
                             Attribute::Instance {
                                 name: QualifiedName::new(None, "a2"),
-                                value: AttributeValue::Value("w2".into()),
+                                value: AttributeValue::Value("w2".to_string()),
                             },
                             Attribute::Instance {
                                 name: QualifiedName::new(None, "a3"),
-                                value: AttributeValue::Value("v3".into()),
+                                value: AttributeValue::Value("v3".to_string()),
                             },
                         ]),
                         state: TagState::Empty,
@@ -2241,8 +2193,7 @@ fn test_valid_sa_044() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_045() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("045", &mut buffer)?;
+    let document = test_valid_sa_file("045")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2266,12 +2217,12 @@ fn test_valid_sa_045() -> Result<(), Box<dyn Error>> {
                                 Attribute::Definition {
                                     name: QualifiedName::new(None, "a1"),
                                     att_type: AttType::CDATA,
-                                    default_decl: DefaultDecl::Value("v1".into()),
+                                    default_decl: DefaultDecl::Value("v1".to_string()),
                                 },
                                 Attribute::Definition {
                                     name: QualifiedName::new(None, "a1"),
                                     att_type: AttType::CDATA,
-                                    default_decl: DefaultDecl::Value("z1".into()),
+                                    default_decl: DefaultDecl::Value("z1".to_string()),
                                 },
                             ]),
                         },
@@ -2298,8 +2249,7 @@ fn test_valid_sa_045() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_046() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("046", &mut buffer)?;
+    let document = test_valid_sa_file("046")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2323,12 +2273,12 @@ fn test_valid_sa_046() -> Result<(), Box<dyn Error>> {
                                 Attribute::Definition {
                                     name: QualifiedName::new(None, "a1"),
                                     att_type: AttType::CDATA,
-                                    default_decl: DefaultDecl::Value("v1".into()),
+                                    default_decl: DefaultDecl::Value("v1".to_string()),
                                 },
                                 Attribute::Definition {
                                     name: QualifiedName::new(None, "a2"),
                                     att_type: AttType::CDATA,
-                                    default_decl: DefaultDecl::Value("v2".into()),
+                                    default_decl: DefaultDecl::Value("v2".to_string()),
                                 },
                             ]),
                         },
@@ -2355,8 +2305,7 @@ fn test_valid_sa_046() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_047() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("047", &mut buffer)?;
+    let document = test_valid_sa_file("047")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2381,7 +2330,7 @@ fn test_valid_sa_047() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some("X\nY".into()))),
+                Box::new(Document::Content(Some("X\nY".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -2395,8 +2344,7 @@ fn test_valid_sa_047() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_048() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("048", &mut buffer)?;
+    let document = test_valid_sa_file("048")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2421,7 +2369,7 @@ fn test_valid_sa_048() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some("]".into()))),
+                Box::new(Document::Content(Some("]".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -2435,8 +2383,7 @@ fn test_valid_sa_048() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_049() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("049", &mut buffer)?;
+    let document = test_valid_sa_file("049")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2461,7 +2408,7 @@ fn test_valid_sa_049() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some("£".into()))),
+                Box::new(Document::Content(Some("£".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -2475,8 +2422,7 @@ fn test_valid_sa_049() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_050() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("050", &mut buffer)?;
+    let document = test_valid_sa_file("050")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2501,7 +2447,7 @@ fn test_valid_sa_050() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some("เจมส์".into()))),
+                Box::new(Document::Content(Some("เจมส์".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -2515,8 +2461,7 @@ fn test_valid_sa_050() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_051() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("051", &mut buffer)?;
+    let document = test_valid_sa_file("051")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2555,8 +2500,7 @@ fn test_valid_sa_051() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_052() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("052", &mut buffer)?;
+    let document = test_valid_sa_file("052")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2581,7 +2525,7 @@ fn test_valid_sa_052() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some("𐀀􏿽".into()))),
+                Box::new(Document::Content(Some("𐀀􏿽".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -2595,8 +2539,7 @@ fn test_valid_sa_052() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_053() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("053", &mut buffer)?;
+    let document = test_valid_sa_file("053")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2610,7 +2553,7 @@ fn test_valid_sa_053() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "<e/>".into()
+                                "<e/>".to_string()
                             ))
                         })),
                         InternalSubset::Element {
@@ -2657,8 +2600,7 @@ fn test_valid_sa_053() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_054() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("054", &mut buffer)?;
+    let document = test_valid_sa_file("054")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2698,8 +2640,7 @@ fn test_valid_sa_054() -> Result<(), Box<dyn Error>> {
 // TODO: analyze the misc to see if Some(Vec<Misc.content(Box<Document::Nested>)>) is correct
 #[test]
 fn test_valid_sa_055() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("055", &mut buffer)?;
+    let document = test_valid_sa_file("055")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2709,7 +2650,7 @@ fn test_valid_sa_055() -> Result<(), Box<dyn Error>> {
                     content: Box::new(Document::Nested(vec![Document::ProcessingInstruction(
                         ProcessingInstruction {
                             target: QualifiedName::new(None, "pi"),
-                            data: Some("data".into()),
+                            data: Some("data".to_string()),
                         }
                     )])),
                     state: MiscState::AfterDoctype,
@@ -2746,8 +2687,7 @@ fn test_valid_sa_055() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_056() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("056", &mut buffer)?;
+    let document = test_valid_sa_file("056")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2772,7 +2712,7 @@ fn test_valid_sa_056() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Borrowed("A")))), // '&#x0000000000000000000000000000000000000041;' decodes to 'A'
+                Box::new(Document::Content(Some("A".to_string()))), // '&#x0000000000000000000000000000000000000041;' decodes to 'A'
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -2786,8 +2726,7 @@ fn test_valid_sa_056() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_057() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("057", &mut buffer)?;
+    let document = test_valid_sa_file("057")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2831,8 +2770,7 @@ fn test_valid_sa_057() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_058() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("058", &mut buffer)?;
+    let document = test_valid_sa_file("058")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2866,7 +2804,7 @@ fn test_valid_sa_058() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a1"),
-                        value: AttributeValue::Value(" 1  	2 	".into()), // The attribute value from the input
+                        value: AttributeValue::Value(" 1  	2 	".to_string()), // The attribute value from the input
                     },]),
                     state: TagState::Start,
                 },
@@ -2884,8 +2822,7 @@ fn test_valid_sa_058() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_059() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("059", &mut buffer)?;
+    let document = test_valid_sa_file("059")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -2947,15 +2884,15 @@ fn test_valid_sa_059() -> Result<(), Box<dyn Error>> {
                         attributes: Some(vec![
                             Attribute::Instance {
                                 name: QualifiedName::new(None, "a1"),
-                                value: AttributeValue::Value("v1".into()),
+                                value: AttributeValue::Value("v1".to_string()),
                             },
                             Attribute::Instance {
                                 name: QualifiedName::new(None, "a2"),
-                                value: AttributeValue::Value("v2".into()),
+                                value: AttributeValue::Value("v2".to_string()),
                             },
                             Attribute::Instance {
                                 name: QualifiedName::new(None, "a3"),
-                                value: AttributeValue::Value("v3".into()),
+                                value: AttributeValue::Value("v3".to_string()),
                             },
                         ]),
                         state: TagState::Empty,
@@ -2965,11 +2902,11 @@ fn test_valid_sa_059() -> Result<(), Box<dyn Error>> {
                         attributes: Some(vec![
                             Attribute::Instance {
                                 name: QualifiedName::new(None, "a1"),
-                                value: AttributeValue::Value("w1".into()),
+                                value: AttributeValue::Value("w1".to_string()),
                             },
                             Attribute::Instance {
                                 name: QualifiedName::new(None, "a2"),
-                                value: AttributeValue::Value("v2".into()),
+                                value: AttributeValue::Value("v2".to_string()),
                             },
                         ]),
                         state: TagState::Empty,
@@ -2979,15 +2916,15 @@ fn test_valid_sa_059() -> Result<(), Box<dyn Error>> {
                         attributes: Some(vec![
                             Attribute::Instance {
                                 name: QualifiedName::new(None, "a1"),
-                                value: AttributeValue::Value("v1".into()),
+                                value: AttributeValue::Value("v1".to_string()),
                             },
                             Attribute::Instance {
                                 name: QualifiedName::new(None, "a2"),
-                                value: AttributeValue::Value("w2".into()),
+                                value: AttributeValue::Value("w2".to_string()),
                             },
                             Attribute::Instance {
                                 name: QualifiedName::new(None, "a3"),
-                                value: AttributeValue::Value("v3".into()),
+                                value: AttributeValue::Value("v3".to_string()),
                             },
                         ]),
                         state: TagState::Empty,
@@ -3006,8 +2943,7 @@ fn test_valid_sa_059() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_060() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("060", &mut buffer)?;
+    let document = test_valid_sa_file("060")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3032,11 +2968,11 @@ fn test_valid_sa_060() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                //TODO: consider if this should be merged into Document::Content(Some("X\nY".into())),. Significant reworking needed to do this.
+                //TODO: consider if this should be merged into Document::Content(Some("X\nY".to_string())),. Significant reworking needed to do this.
                 Box::new(Document::Nested(vec![
-                    Document::Content(Some("X".into())),
-                    Document::Content(Some("\n".into())),
-                    Document::Content(Some("Y".into())),
+                    Document::Content(Some("X".to_string())),
+                    Document::Content(Some("\n".to_string())),
+                    Document::Content(Some("Y".to_string())),
                 ])),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
@@ -3051,8 +2987,7 @@ fn test_valid_sa_060() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_061() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("061", &mut buffer)?;
+    let document = test_valid_sa_file("061")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3077,7 +3012,7 @@ fn test_valid_sa_061() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Borrowed("£")))),
+                Box::new(Document::Content(Some("£".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -3091,8 +3026,7 @@ fn test_valid_sa_061() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_062() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("062", &mut buffer)?;
+    let document = test_valid_sa_file("062")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3119,8 +3053,8 @@ fn test_valid_sa_062() -> Result<(), Box<dyn Error>> {
                 },
                 Box::new(Document::Nested(vec![
                     //TODO: Same as test 60, should this all be combined?
-                    Document::Content(Some(Cow::Borrowed("เจม"))),
-                    Document::Content(Some(Cow::Borrowed("ส์"))),
+                    Document::Content(Some("เจม".to_string())),
+                    Document::Content(Some("ส์".to_string())),
                 ])),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
@@ -3135,8 +3069,7 @@ fn test_valid_sa_062() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_063() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("063", &mut buffer)?;
+    let document = test_valid_sa_file("063")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3175,8 +3108,7 @@ fn test_valid_sa_063() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_064() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("064", &mut buffer)?;
+    let document = test_valid_sa_file("064")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3201,9 +3133,7 @@ fn test_valid_sa_064() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Borrowed(
-                    "\u{10000}\u{10FFFD}"
-                )))),
+                Box::new(Document::Content(Some("\u{10000}\u{10FFFD}".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -3217,8 +3147,7 @@ fn test_valid_sa_064() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_065() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("065", &mut buffer)?;
+    let document = test_valid_sa_file("065")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3232,7 +3161,7 @@ fn test_valid_sa_065() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Reference(
-                                Reference::CharRef("<".into())
+                                Reference::CharRef("<".to_string())
                             )),
                         })),
                         InternalSubset::Element {
@@ -3265,8 +3194,7 @@ fn test_valid_sa_065() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_066() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("066", &mut buffer)?;
+    let document = test_valid_sa_file("066")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3292,11 +3220,13 @@ fn test_valid_sa_066() -> Result<(), Box<dyn Error>> {
                                 default_decl: DefaultDecl::Implied,
                             }]),
                         },
-                        InternalSubset::Comment(Document::Comment(" 34 is double quote ".into())),
+                        InternalSubset::Comment(Document::Comment(
+                            " 34 is double quote ".to_string()
+                        )),
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e1"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Reference(
-                                Reference::CharRef("\"".into())
+                                Reference::CharRef("\"".to_string())
                             )),
                         })),
                     ]),
@@ -3307,7 +3237,7 @@ fn test_valid_sa_066() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a1"),
-                        value: AttributeValue::Value("\"".into()),
+                        value: AttributeValue::Value("\"".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -3325,8 +3255,7 @@ fn test_valid_sa_066() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_067() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("067", &mut buffer)?;
+    let document = test_valid_sa_file("067")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3351,7 +3280,7 @@ fn test_valid_sa_067() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Borrowed("\r")))),
+                Box::new(Document::Content(Some("\r".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -3365,8 +3294,7 @@ fn test_valid_sa_067() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_068() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("068", &mut buffer)?;
+    let document = test_valid_sa_file("068")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3387,7 +3315,7 @@ fn test_valid_sa_068() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Reference(
-                                Reference::CharRef("\r".into())
+                                Reference::CharRef("\r".to_string())
                             )),
                         })),
                     ]),
@@ -3399,7 +3327,7 @@ fn test_valid_sa_068() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Borrowed("\r")))), // "&#13;" is a carriage return
+                Box::new(Document::Content(Some("\r".to_string()))), // "&#13;" is a carriage return
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -3413,8 +3341,7 @@ fn test_valid_sa_068() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_069() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("069", &mut buffer)?;
+    let document = test_valid_sa_file("069")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3434,7 +3361,7 @@ fn test_valid_sa_069() -> Result<(), Box<dyn Error>> {
                         },
                         InternalSubset::Notation {
                             name: QualifiedName::new(None, "n"),
-                            id: ID::PublicID("whatever".into()),
+                            id: ID::PublicID("whatever".to_string()),
                         },
                     ]),
                 }),
@@ -3459,8 +3386,7 @@ fn test_valid_sa_069() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_070() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("070", &mut buffer)?;
+    let document = test_valid_sa_file("070")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3470,28 +3396,28 @@ fn test_valid_sa_070() -> Result<(), Box<dyn Error>> {
                 doc_type: Some(DocType {
                     name: QualifiedName {
                         prefix: None,
-                        local_part: "doc".into(),
+                        local_part: "doc".to_string(),
                     },
                     external_id: None,
                     int_subset: Some(vec![
                         InternalSubset::Entity(EntityDecl::Parameter(EntityDeclaration {
                             name: QualifiedName {
                                 prefix: None,
-                                local_part: "e".into(),
+                                local_part: "e".to_string(),
                             },
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "<!ELEMENT doc (#PCDATA)>".into()
+                                "<!ELEMENT doc (#PCDATA)>".to_string()
                             )),
                         })),
                         InternalSubset::DeclSep {
                             reference: Reference::EntityRef(QualifiedName {
                                 prefix: None,
-                                local_part: "e".into(),
+                                local_part: "e".to_string(),
                             }),
                             expansion: Some(Box::new(InternalSubset::Element {
                                 name: QualifiedName {
                                     prefix: None,
-                                    local_part: "doc".into(),
+                                    local_part: "doc".to_string(),
                                 },
                                 content_spec: Some(DeclarationContent::Mixed(Mixed::PCDATA {
                                     names: None,
@@ -3506,7 +3432,7 @@ fn test_valid_sa_070() -> Result<(), Box<dyn Error>> {
                 Tag {
                     name: QualifiedName {
                         prefix: None,
-                        local_part: "doc".into(),
+                        local_part: "doc".to_string(),
                     },
                     attributes: None,
                     state: TagState::Start,
@@ -3515,7 +3441,7 @@ fn test_valid_sa_070() -> Result<(), Box<dyn Error>> {
                 Tag {
                     name: QualifiedName {
                         prefix: None,
-                        local_part: "doc".into(),
+                        local_part: "doc".to_string(),
                     },
                     attributes: None,
                     state: TagState::End,
@@ -3528,8 +3454,7 @@ fn test_valid_sa_070() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_071() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("071", &mut buffer)?;
+    let document = test_valid_sa_file("071")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3578,8 +3503,7 @@ fn test_valid_sa_071() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_072() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("072", &mut buffer)?;
+    let document = test_valid_sa_file("072")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3628,8 +3552,7 @@ fn test_valid_sa_072() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_073() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("073", &mut buffer)?;
+    let document = test_valid_sa_file("073")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3678,8 +3601,7 @@ fn test_valid_sa_073() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_074() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("074", &mut buffer)?;
+    let document = test_valid_sa_file("074")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3728,8 +3650,7 @@ fn test_valid_sa_074() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_075() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("075", &mut buffer)?;
+    let document = test_valid_sa_file("075")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3778,8 +3699,7 @@ fn test_valid_sa_075() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_076() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("076", &mut buffer)?;
+    let document = test_valid_sa_file("076")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3813,15 +3733,15 @@ fn test_valid_sa_076() -> Result<(), Box<dyn Error>> {
                         },
                         InternalSubset::Notation {
                             name: QualifiedName::new(None, "n1"),
-                            id: ID::ExternalID(ExternalID::System(Cow::Borrowed(
-                                "http://www.w3.org/"
-                            ))),
+                            id: ID::ExternalID(ExternalID::System(
+                                "http://www.w3.org/".to_string()
+                            )),
                         },
                         InternalSubset::Notation {
                             name: QualifiedName::new(None, "n2"),
-                            id: ID::ExternalID(ExternalID::System(Cow::Borrowed(
-                                "http://www.w3.org/"
-                            ))),
+                            id: ID::ExternalID(ExternalID::System(
+                                "http://www.w3.org/".to_string()
+                            )),
                         },
                     ]),
                 }),
@@ -3846,8 +3766,7 @@ fn test_valid_sa_076() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_077() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("077", &mut buffer)?;
+    let document = test_valid_sa_file("077")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3871,7 +3790,7 @@ fn test_valid_sa_077() -> Result<(), Box<dyn Error>> {
                                 name: QualifiedName::new(None, "a"),
                                 att_type: AttType::Enumerated {
                                     notation: None,
-                                    enumeration: Some(vec![Cow::Borrowed("1"), Cow::Borrowed("2")]),
+                                    enumeration: Some(vec!["1".to_string(), "2".to_string()]),
                                 },
                                 default_decl: DefaultDecl::Implied,
                             }]),
@@ -3899,8 +3818,7 @@ fn test_valid_sa_077() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_078() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("078", &mut buffer)?;
+    let document = test_valid_sa_file("078")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3934,7 +3852,7 @@ fn test_valid_sa_078() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a"),
-                        value: AttributeValue::Value("v".into()),
+                        value: AttributeValue::Value("v".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -3952,8 +3870,7 @@ fn test_valid_sa_078() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_079() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("079", &mut buffer)?;
+    let document = test_valid_sa_file("079")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -3976,7 +3893,7 @@ fn test_valid_sa_079() -> Result<(), Box<dyn Error>> {
                             att_defs: Some(vec![Attribute::Definition {
                                 name: QualifiedName::new(None, "a"),
                                 att_type: AttType::CDATA,
-                                default_decl: DefaultDecl::Fixed(Cow::Borrowed("v")),
+                                default_decl: DefaultDecl::Fixed("v".to_string()),
                             }]),
                         },
                     ]),
@@ -3987,7 +3904,7 @@ fn test_valid_sa_079() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a"),
-                        value: AttributeValue::Value("v".into()),
+                        value: AttributeValue::Value("v".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -4005,8 +3922,7 @@ fn test_valid_sa_079() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_080() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("080", &mut buffer)?;
+    let document = test_valid_sa_file("080")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4029,7 +3945,7 @@ fn test_valid_sa_080() -> Result<(), Box<dyn Error>> {
                             att_defs: Some(vec![Attribute::Definition {
                                 name: QualifiedName::new(None, "a"),
                                 att_type: AttType::CDATA,
-                                default_decl: DefaultDecl::Fixed(Cow::Borrowed("v")),
+                                default_decl: DefaultDecl::Fixed("v".to_string()),
                             }]),
                         },
                     ]),
@@ -4056,8 +3972,7 @@ fn test_valid_sa_080() -> Result<(), Box<dyn Error>> {
 // TODO: test 081
 #[test]
 fn test_valid_sa_081() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("081", &mut buffer)?;
+    let document = test_valid_sa_file("081")?;
 
     assert_eq!(
         document,
@@ -4184,8 +4099,7 @@ fn test_valid_sa_081() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_082() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("082", &mut buffer)?;
+    let document = test_valid_sa_file("082")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4197,9 +4111,9 @@ fn test_valid_sa_082() -> Result<(), Box<dyn Error>> {
                     external_id: None,
                     int_subset: Some(vec![
                         InternalSubset::Entity(EntityDecl::Parameter(EntityDeclaration {
-                            name: QualifiedName::new(None, "e".into()),
+                            name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::External {
-                                id: ExternalID::System(Cow::Borrowed("e.dtd")),
+                                id: ExternalID::System("e.dtd".to_string()),
                                 n_data: None,
                             },
                         })),
@@ -4234,8 +4148,7 @@ fn test_valid_sa_082() -> Result<(), Box<dyn Error>> {
 //TODO: test 083
 #[test]
 fn test_valid_sa_083() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("083", &mut buffer)?;
+    let document = test_valid_sa_file("083")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4250,10 +4163,10 @@ fn test_valid_sa_083() -> Result<(), Box<dyn Error>> {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::External {
                                 id: ExternalID::Public {
-                                    pubid: Cow::Borrowed("whatever"),
-                                    system_identifier: Box::new(ExternalID::System(Cow::Borrowed(
-                                        "e.dtd"
-                                    ))),
+                                    pubid: "whatever".to_string(),
+                                    system_identifier: Box::new(ExternalID::System(
+                                        "e.dtd".to_string()
+                                    )),
                                 },
                                 n_data: None,
                             },
@@ -4288,8 +4201,7 @@ fn test_valid_sa_083() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_084() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("084", &mut buffer)?;
+    let document = test_valid_sa_file("084")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4328,8 +4240,7 @@ fn test_valid_sa_084() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_085() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("085", &mut buffer)?;
+    let document = test_valid_sa_file("085")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4350,13 +4261,13 @@ fn test_valid_sa_085() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::Parameter(EntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "<foo>".into()
+                                "<foo>".to_string()
                             )),
                         })),
                         InternalSubset::Entity(EntityDecl::General(EntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "".into()
+                                "".to_string()
                             )),
                         })),
                     ]),
@@ -4368,7 +4279,7 @@ fn test_valid_sa_085() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Borrowed("<foo>")))),
+                Box::new(Document::Content(Some("<foo>".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -4382,8 +4293,7 @@ fn test_valid_sa_085() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_086() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("086", &mut buffer)?;
+    let document = test_valid_sa_file("086")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4404,13 +4314,13 @@ fn test_valid_sa_086() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "".into()
+                                "".to_string()
                             )),
                         })),
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "<foo>".into()
+                                "<foo>".to_string()
                             )),
                         })),
                     ]),
@@ -4422,7 +4332,7 @@ fn test_valid_sa_086() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Borrowed("")))),
+                Box::new(Document::Content(Some("".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -4436,8 +4346,7 @@ fn test_valid_sa_086() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_087() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("087", &mut buffer)?;
+    let document = test_valid_sa_file("087")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4451,7 +4360,7 @@ fn test_valid_sa_087() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "<foo/&#62;".into()
+                                "<foo/&#62;".to_string()
                             )),
                         })),
                         InternalSubset::Element {
@@ -4497,8 +4406,7 @@ fn test_valid_sa_087() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_088() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("088", &mut buffer)?;
+    let document = test_valid_sa_file("088")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4519,7 +4427,7 @@ fn test_valid_sa_088() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "<foo>".into()
+                                "<foo>".to_string()
                             )),
                         })),
                     ]),
@@ -4531,7 +4439,7 @@ fn test_valid_sa_088() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Borrowed("<foo>")))), // Assumed to be a string because it's only an open tag
+                Box::new(Document::Content(Some("<foo>".to_string()))), // Assumed to be a string because it's only an open tag
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -4545,8 +4453,7 @@ fn test_valid_sa_088() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_089() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("089", &mut buffer)?;
+    let document = test_valid_sa_file("089")?;
 
     assert_eq!(
         document,
@@ -4561,7 +4468,7 @@ fn test_valid_sa_089() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "\u{10000}\u{10FFFD}\u{10FFFF}".into()
+                                "\u{10000}\u{10FFFD}\u{10FFFF}".to_string()
                             )),
                         })),
                         InternalSubset::Element {
@@ -4580,9 +4487,9 @@ fn test_valid_sa_089() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Borrowed(
-                    "\u{10000}\u{10FFFD}\u{10FFFF}"
-                )))),
+                Box::new(Document::Content(Some(
+                    "\u{10000}\u{10FFFD}\u{10FFFF}".to_string()
+                ))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -4596,8 +4503,7 @@ fn test_valid_sa_089() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_090() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("090", &mut buffer)?;
+    let document = test_valid_sa_file("090")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4640,7 +4546,7 @@ fn test_valid_sa_090() -> Result<(), Box<dyn Error>> {
                         },
                         InternalSubset::Notation {
                             name: QualifiedName::new(None, "n"),
-                            id: ID::PublicID("whatever".into()),
+                            id: ID::PublicID("whatever".to_string()),
                         }
                     ]),
                 }),
@@ -4665,8 +4571,7 @@ fn test_valid_sa_090() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_091() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("091", &mut buffer)?;
+    let document = test_valid_sa_file("091")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4679,14 +4584,14 @@ fn test_valid_sa_091() -> Result<(), Box<dyn Error>> {
                     int_subset: Some(vec![
                         InternalSubset::Notation {
                             name: QualifiedName::new(None, "n"),
-                            id: ID::ExternalID(ExternalID::System(Cow::Borrowed(
-                                "http://www.w3.org/"
-                            )))
+                            id: ID::ExternalID(ExternalID::System(
+                                "http://www.w3.org/".to_string()
+                            ))
                         },
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::External {
-                                id: ExternalID::System(Cow::Borrowed("http://www.w3.org/")),
+                                id: ExternalID::System("http://www.w3.org/".to_string()),
                                 n_data: Some(QualifiedName::new(None, "n")),
                             }
                         })),
@@ -4702,7 +4607,7 @@ fn test_valid_sa_091() -> Result<(), Box<dyn Error>> {
                             att_defs: Some(vec![Attribute::Definition {
                                 name: QualifiedName::new(None, "a"),
                                 att_type: AttType::Tokenized(TokenizedType::ENTITY),
-                                default_decl: DefaultDecl::Value(Cow::Borrowed("e")),
+                                default_decl: DefaultDecl::Value("e".to_string()),
                             }]),
                         }
                     ]),
@@ -4728,8 +4633,7 @@ fn test_valid_sa_091() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_092() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("092", &mut buffer)?;
+    let document = test_valid_sa_file("092")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4795,8 +4699,7 @@ fn test_valid_sa_092() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_093() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("093", &mut buffer)?;
+    let document = test_valid_sa_file("093")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4835,8 +4738,7 @@ fn test_valid_sa_093() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_094() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("094", &mut buffer)?;
+    let document = test_valid_sa_file("094")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4850,7 +4752,7 @@ fn test_valid_sa_094() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::Parameter(EntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "foo".into()
+                                "foo".to_string()
                             )),
                         })),
                         InternalSubset::Element {
@@ -4865,7 +4767,7 @@ fn test_valid_sa_094() -> Result<(), Box<dyn Error>> {
                             att_defs: Some(vec![Attribute::Definition {
                                 name: QualifiedName::new(None, "a1"),
                                 att_type: AttType::CDATA,
-                                default_decl: DefaultDecl::Value("%e;".into()),
+                                default_decl: DefaultDecl::Value("%e;".to_string()),
                             }]),
                         },
                     ]),
@@ -4891,8 +4793,7 @@ fn test_valid_sa_094() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_095() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("095", &mut buffer)?;
+    let document = test_valid_sa_file("095")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4933,7 +4834,7 @@ fn test_valid_sa_095() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a1"),
-                        value: AttributeValue::Value("1  2".into()),
+                        value: AttributeValue::Value("1  2".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -4951,8 +4852,7 @@ fn test_valid_sa_095() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_096() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("096", &mut buffer)?;
+    let document = test_valid_sa_file("096")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -4968,7 +4868,7 @@ fn test_valid_sa_096() -> Result<(), Box<dyn Error>> {
                             att_defs: Some(vec![Attribute::Definition {
                                 name: QualifiedName::new(None, "a1"),
                                 att_type: AttType::Tokenized(TokenizedType::NMTOKENS),
-                                default_decl: DefaultDecl::Value(" 1  \t2 \t".into()),
+                                default_decl: DefaultDecl::Value(" 1  \t2 \t".to_string()),
                             }]),
                         },
                         InternalSubset::Element {
@@ -5002,8 +4902,7 @@ fn test_valid_sa_096() -> Result<(), Box<dyn Error>> {
 //TODO: Test 097 with lookup in test 097.ent
 #[test]
 fn test_valid_sa_097() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("097", &mut buffer)?;
+    let document = test_valid_sa_file("097")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5026,13 +4925,13 @@ fn test_valid_sa_097() -> Result<(), Box<dyn Error>> {
                             att_defs: Some(vec![Attribute::Definition {
                                 name: QualifiedName::new(None, "a1"),
                                 att_type: AttType::CDATA,
-                                default_decl: DefaultDecl::Value(Cow::Borrowed("v1")),
+                                default_decl: DefaultDecl::Value("v1".to_string()),
                             }]),
                         },
                         InternalSubset::Entity(EntityDecl::Parameter(ParameterEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::External {
-                                id: ExternalID::System(Cow::Borrowed("097.ent")),
+                                id: ExternalID::System("097.ent".to_string()),
                                 n_data: None,
                             },
                         })),
@@ -5050,7 +4949,7 @@ fn test_valid_sa_097() -> Result<(), Box<dyn Error>> {
                                 att_defs: Some(vec![Attribute::Definition {
                                     name: QualifiedName::new(None, "a2"),
                                     att_type: AttType::CDATA,
-                                    default_decl: DefaultDecl::Value(Cow::Borrowed("v2")),
+                                    default_decl: DefaultDecl::Value("v2".to_string()),
                                 }]),
                             }),
                         ]),
@@ -5077,8 +4976,7 @@ fn test_valid_sa_097() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_098() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("098", &mut buffer)?;
+    let document = test_valid_sa_file("098")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5105,7 +5003,7 @@ fn test_valid_sa_098() -> Result<(), Box<dyn Error>> {
                 },
                 Box::new(Document::ProcessingInstruction(ProcessingInstruction {
                     target: QualifiedName::new(None, "pi"),
-                    data: Some(Cow::Borrowed("x\ny")),
+                    data: Some("x\ny".to_string()),
                 })),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
@@ -5120,16 +5018,15 @@ fn test_valid_sa_098() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_099() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("099", &mut buffer)?;
+    let document = test_valid_sa_file("099")?;
 
     assert_eq!(
         document,
         Document::Nested(vec![
             Document::Prolog {
                 xml_decl: Some(XmlDecl {
-                    version: Cow::Borrowed("1.0"),
-                    encoding: Some(Cow::Borrowed("utf-8")),
+                    version: "1.0".to_string(),
+                    encoding: Some("utf-8".to_string()),
                     standalone: None,
                 }),
                 misc: None,
@@ -5166,8 +5063,7 @@ fn test_valid_sa_099() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_100() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("100", &mut buffer)?;
+    let document = test_valid_sa_file("100")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5182,9 +5078,9 @@ fn test_valid_sa_100() -> Result<(), Box<dyn Error>> {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::External {
                                 id: ExternalID::Public {
-                                    pubid: ";!*#@$_%".into(),
+                                    pubid: ";!*#@$_%".to_string(),
                                     system_identifier: Box::new(ExternalID::System(
-                                        "100.xml".into()
+                                        "100.xml".to_string()
                                     ))
                                 },
                                 n_data: None,
@@ -5220,8 +5116,7 @@ fn test_valid_sa_100() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_101() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("101", &mut buffer)?;
+    let document = test_valid_sa_file("101")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5242,7 +5137,7 @@ fn test_valid_sa_101() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Reference(
-                                Reference::CharRef("\"".into())
+                                Reference::CharRef("\"".to_string())
                             )),
                         })),
                     ]),
@@ -5268,8 +5163,7 @@ fn test_valid_sa_101() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_102() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("102", &mut buffer)?;
+    let document = test_valid_sa_file("102")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5303,7 +5197,7 @@ fn test_valid_sa_102() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a"),
-                        value: AttributeValue::Value("\"".into()),
+                        value: AttributeValue::Value("\"".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -5321,8 +5215,7 @@ fn test_valid_sa_102() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_103() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("103", &mut buffer)?;
+    let document = test_valid_sa_file("103")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5348,8 +5241,8 @@ fn test_valid_sa_103() -> Result<(), Box<dyn Error>> {
                     state: TagState::Start,
                 },
                 Box::new(Document::Nested(vec![
-                    Document::Content(Some("<".into())), //TODO: look at post-processing step to merge these into <doc> then parse it as an element
-                    Document::Content(Some("doc>".into())),
+                    Document::Content(Some("<".to_string())), //TODO: look at post-processing step to merge these into <doc> then parse it as an element
+                    Document::Content(Some("doc>".to_string())),
                 ]),),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
@@ -5364,8 +5257,7 @@ fn test_valid_sa_103() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_104() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("104", &mut buffer)?;
+    let document = test_valid_sa_file("104")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5399,7 +5291,7 @@ fn test_valid_sa_104() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a"),
-                        value: AttributeValue::Value("x\ty".into()), // decoded tab character
+                        value: AttributeValue::Value("x\ty".to_string()), // decoded tab character
                     }]),
                     state: TagState::Start,
                 },
@@ -5417,8 +5309,7 @@ fn test_valid_sa_104() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_105() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("105", &mut buffer)?;
+    let document = test_valid_sa_file("105")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5452,7 +5343,7 @@ fn test_valid_sa_105() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a"),
-                        value: AttributeValue::Value("x\ty".into()),
+                        value: AttributeValue::Value("x\ty".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -5470,8 +5361,7 @@ fn test_valid_sa_105() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_106() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("106", &mut buffer)?;
+    let document = test_valid_sa_file("106")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5505,7 +5395,7 @@ fn test_valid_sa_106() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a"),
-                        value: AttributeValue::Value("x\ny".into()),
+                        value: AttributeValue::Value("x\ny".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -5523,8 +5413,7 @@ fn test_valid_sa_106() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_107() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("107", &mut buffer)?;
+    let document = test_valid_sa_file("107")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5558,7 +5447,7 @@ fn test_valid_sa_107() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a"),
-                        value: AttributeValue::Value("x\ny".into()),
+                        value: AttributeValue::Value("x\ny".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -5576,8 +5465,7 @@ fn test_valid_sa_107() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_108() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("108", &mut buffer)?;
+    let document = test_valid_sa_file("108")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5598,7 +5486,7 @@ fn test_valid_sa_108() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "\n".into()
+                                "\n".to_string()
                             )),
                         })),
                         InternalSubset::AttList {
@@ -5617,7 +5505,7 @@ fn test_valid_sa_108() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a"),
-                        value: AttributeValue::Value("x\ny".into()),
+                        value: AttributeValue::Value("x\ny".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -5635,8 +5523,7 @@ fn test_valid_sa_108() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_109() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("109", &mut buffer)?;
+    let document = test_valid_sa_file("109")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5670,7 +5557,7 @@ fn test_valid_sa_109() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a"),
-                        value: AttributeValue::Value("".into()),
+                        value: AttributeValue::Value("".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -5689,8 +5576,7 @@ fn test_valid_sa_109() -> Result<(), Box<dyn Error>> {
 //TODO: Test 110. Need to verify normalization behavior for `\r\n` current parsing replaces all instances of that with `\n`
 #[test]
 fn test_valid_sa_110() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("110", &mut buffer)?;
+    let document = test_valid_sa_file("110")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5711,7 +5597,7 @@ fn test_valid_sa_110() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "\r\n".into()
+                                "\r\n".to_string()
                             )),
                         })),
                         InternalSubset::AttList {
@@ -5730,7 +5616,7 @@ fn test_valid_sa_110() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a"),
-                        value: AttributeValue::Value("x\ny".into()),
+                        value: AttributeValue::Value("x\ny".to_string()),
                     }]),
                     state: TagState::Start,
                 },
@@ -5748,8 +5634,7 @@ fn test_valid_sa_110() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_111() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("111", &mut buffer)?;
+    let document = test_valid_sa_file("111")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5783,7 +5668,7 @@ fn test_valid_sa_111() -> Result<(), Box<dyn Error>> {
                     name: QualifiedName::new(None, "doc"),
                     attributes: Some(vec![Attribute::Instance {
                         name: QualifiedName::new(None, "a"),
-                        value: AttributeValue::Value(" x  y ".into()), // &#32; decodes to space
+                        value: AttributeValue::Value(" x  y ".to_string()), // &#32; decodes to space
                     }]),
                     state: TagState::Start,
                 },
@@ -5802,8 +5687,7 @@ fn test_valid_sa_111() -> Result<(), Box<dyn Error>> {
 //TODO: test 112
 #[test]
 fn test_valid_sa_112() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("112", &mut buffer)?;
+    let document = test_valid_sa_file("112")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5873,8 +5757,7 @@ fn test_valid_sa_112() -> Result<(), Box<dyn Error>> {
 }
 #[test]
 fn test_valid_sa_113() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("113", &mut buffer)?;
+    let document = test_valid_sa_file("113")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5924,8 +5807,7 @@ fn test_valid_sa_113() -> Result<(), Box<dyn Error>> {
 //TODO: Test 114. may need to decode within the Document::Element section instead of directly in the attribute because CDATA is not supposed to decode and if it's in the content, then it should avoid decoding
 #[test]
 fn test_valid_sa_114() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("114", &mut buffer)?;
+    let document = test_valid_sa_file("114")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -5946,7 +5828,7 @@ fn test_valid_sa_114() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "<![CDATA[&foo;]]>".into()
+                                "<![CDATA[&foo;]]>".to_string()
                             )),
                         })),
                     ]),
@@ -5958,7 +5840,7 @@ fn test_valid_sa_114() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::CDATA(Cow::Borrowed("&foo;"))),
+                Box::new(Document::CDATA("&foo;".to_string())),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -5973,8 +5855,7 @@ fn test_valid_sa_114() -> Result<(), Box<dyn Error>> {
 //TODO: Test 115
 #[test]
 fn test_valid_sa_115() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("115", &mut buffer)?;
+    let document = test_valid_sa_file("115")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -6001,7 +5882,7 @@ fn test_valid_sa_115() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "e2"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "v".into()
+                                "v".to_string()
                             )),
                         })),
                     ]),
@@ -6013,7 +5894,7 @@ fn test_valid_sa_115() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Borrowed("v")))),
+                Box::new(Document::Content(Some("v".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -6027,8 +5908,7 @@ fn test_valid_sa_115() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_116() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("116", &mut buffer)?;
+    let document = test_valid_sa_file("116")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -6053,7 +5933,7 @@ fn test_valid_sa_116() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::CDATA("\n".into())),
+                Box::new(Document::CDATA("\n".to_string())),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -6067,8 +5947,7 @@ fn test_valid_sa_116() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_117() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("117", &mut buffer)?;
+    let document = test_valid_sa_file("117")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -6089,7 +5968,7 @@ fn test_valid_sa_117() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "rsqb"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "]".into()
+                                "]".to_string()
                             )),
                         })),
                     ]),
@@ -6101,7 +5980,7 @@ fn test_valid_sa_117() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Borrowed("]")))),
+                Box::new(Document::Content(Some("]".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -6115,8 +5994,7 @@ fn test_valid_sa_117() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_118() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("118", &mut buffer)?;
+    let document = test_valid_sa_file("118")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -6137,7 +6015,7 @@ fn test_valid_sa_118() -> Result<(), Box<dyn Error>> {
                         InternalSubset::Entity(EntityDecl::General(GeneralEntityDeclaration {
                             name: QualifiedName::new(None, "rsqb"),
                             entity_def: EntityDefinition::EntityValue(EntityValue::Value(
-                                "]]".into()
+                                "]]".to_string()
                             )),
                         })),
                     ]),
@@ -6149,7 +6027,7 @@ fn test_valid_sa_118() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Content(Some(Cow::Borrowed("]]")))),
+                Box::new(Document::Content(Some("]]".to_string()))),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,
@@ -6163,8 +6041,7 @@ fn test_valid_sa_118() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_valid_sa_119() -> Result<(), Box<dyn Error>> {
-    let mut buffer = String::new();
-    let document = test_valid_sa_file("119", &mut buffer)?;
+    let document = test_valid_sa_file("119")?;
     assert_eq!(
         document,
         Document::Nested(vec![
@@ -6186,7 +6063,7 @@ fn test_valid_sa_119() -> Result<(), Box<dyn Error>> {
                     attributes: None,
                     state: TagState::Start,
                 },
-                Box::new(Document::Comment(Cow::Borrowed(" -á "))),
+                Box::new(Document::Comment(" -á ".to_string())),
                 Tag {
                     name: QualifiedName::new(None, "doc"),
                     attributes: None,


### PR DESCRIPTION
Simplify ownership by moving from Cow<'a str> to String. Removes issues with parsing multiple documents; otherwise, the model would probably have needed into_owned implemented for all of the data structures which would have defeated the purpose of having Cow to begin with